### PR TITLE
Recordingモデルのテスト

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -21,7 +21,7 @@ class PasswordResetsController < ApplicationController
 
     unless @user
       redirect_to new_password_reset_path, alert: "無効または期限切れのリンクです"
-      return
+      nil
     end
   end
 

--- a/app/decorators/password_reset_decorator.rb
+++ b/app/decorators/password_reset_decorator.rb
@@ -9,5 +9,4 @@ class PasswordResetDecorator < Draper::Decorator
   #       object.created_at.strftime("%a %m/%d/%y")
   #     end
   #   end
-
 end

--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -30,7 +30,7 @@ class Recording < ApplicationRecord
 
     max_size = 50.megabytes
     if audio.byte_size > max_size
-      errors.add(:audio, "は50MG以下である必要があります")
+      errors.add(:audio, "は50MB以下である必要があります")
     end
   end
 end

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [:reset_password]
+Rails.application.config.sorcery.submodules = [ :reset_password ]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|

--- a/spec/factories/recordings.rb
+++ b/spec/factories/recordings.rb
@@ -1,10 +1,17 @@
 FactoryBot.define do
   factory :recording do
-    user { nil }
-    child { nil }
-    title { "MyString" }
-    comment { "MyText" }
-    recorded_at { "2026-02-27 12:25:25" }
-    duration { 1 }
+    association :child
+    user { child.user }
+    title { "はじめてのことば" }
+    recorded_at { Time.current }
+    duration { 10 }
+
+    after(:build) do |recording|
+      recording.audio.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/sample.mp3")),
+        filename: "sample.mp3",
+        content_type: "audio/mpeg"
+      )
+    end
   end
 end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,4 +1,3 @@
 # Preview all emails at http://localhost:3000/rails/mailers/user_mailer_mailer
 class UserMailerPreview < ActionMailer::Preview
-
 end

--- a/spec/models/recording_spec.rb
+++ b/spec/models/recording_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Recording, type: :model do
       recording = build(:recording)
       recording.audio.detach
 
-      large_file = Tempfile.new(["large", ".mp3"])
+      large_file = Tempfile.new([ "large", ".mp3" ])
       large_file.binmode
       large_file.write("a" * (51.megabytes))
       large_file.rewind

--- a/spec/models/recording_spec.rb
+++ b/spec/models/recording_spec.rb
@@ -1,5 +1,113 @@
 require 'rails_helper'
 
 RSpec.describe Recording, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "バリデーション" do
+    it "factoryが有効であること" do
+      recording = build(:recording)
+      expect(recording).to be_valid
+    end
+
+    it "title がない場合は無効" do
+      recording = build(:recording, title: nil)
+      expect(recording).to be_invalid
+      expect(recording.errors[:title]).to be_present
+    end
+
+    it "duration がない場合は無効" do
+      recording = build(:recording, duration: nil)
+      expect(recording).to be_invalid
+      expect(recording.errors[:duration]).to be_present
+    end
+
+    it "duration が 0 の場合は無効" do
+      recording = build(:recording, duration: 0)
+      expect(recording).to be_invalid
+      expect(recording.errors[:duration]).to be_present
+    end
+
+    it "duration がマイナスの場合は無効" do
+      recording = build(:recording, duration: -1)
+      expect(recording).to be_invalid
+      expect(recording.errors[:duration]).to be_present
+    end
+
+    it "recorded_at が nil でも作成時に自動生成される" do
+      recording = build(:recording, recorded_at: nil)
+      recording.valid?
+      expect(recording.recorded_at).to be_present
+    end
+
+    it "audio がある場合は有効" do
+      recording = build(:recording)
+      expect(recording.audio).to be_attached
+      expect(recording).to be_valid
+    end
+
+    it "audio がない場合は無効" do
+      recording = build(:recording)
+      recording.audio.detach
+
+      expect(recording).to be_invalid
+      expect(recording.errors[:audio]).to be_present
+    end
+
+    it "許可された content_type の場合は有効" do
+      recording = build(:recording)
+      recording.audio.detach
+
+      recording.audio.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/sample.mp3")),
+        filename: "sample.mp3",
+        content_type: "audio/mpeg"
+      )
+
+      expect(recording).to be_valid
+    end
+
+    it "許可されていない content_type の場合は無効" do
+      recording = build(:recording)
+      recording.audio.detach
+
+      recording.audio.attach(
+        io: StringIO.new("dummy test"),
+        filename: "sample.txt",
+        content_type: "text/plain"
+      )
+
+      expect(recording).to be_invalid
+      expect(recording.errors[:audio]).to be_present
+    end
+
+    it "サイズ制限を超える場合は無効" do
+      recording = build(:recording)
+      recording.audio.detach
+
+      large_file = Tempfile.new(["large", ".mp3"])
+      large_file.binmode
+      large_file.write("a" * (51.megabytes))
+      large_file.rewind
+
+      recording.audio.attach(
+        io: large_file,
+        filename: "large.mp3",
+        content_type: "audio/mpeg"
+      )
+
+      expect(recording).to be_invalid
+      expect(recording.errors[:audio]).to be_present
+
+      large_file.close
+      large_file.unlink
+    end
+
+    it "user に紐付いていること" do
+      recording = build(:recording)
+      expect(recording.user).to be_present
+    end
+
+    it "child に紐付いていること" do
+      recording = build(:recording)
+      expect(recording.child).to be_present
+    end
+  end
 end


### PR DESCRIPTION
## 概要
Recordingモデルが正しい条件で保存できるかを確認する

## 対象ISSUE
close #129 

## 実装内容
- Recording モデルのバリデーションを確認する
- FactoryBot の recording を作る
- テスト用音声ファイルを確認する
- `spec/models/recording_spec.rb` を書く
- まず正常系を1本通す
- presence 系を追加する
- duration の数値条件を追加する
- audio の 有無を追加する
- content_type のテストを追加する
- サイズ制限のテストを追加する
- user / child の関連を確認する
- spec を実行して全部通す

## 完了条件
[ ] `spec/models/recording_spec.rb` を作成している
[ ] `title` のバリデーションをテストしている
[ ] `recorded_at` が自動設定されることをテストしている
[ ] `duration` のバリデーションをテストしている
[ ] `duration` が `0` 以下の場合に無効になることを確認している
[ ] `audio` がある場合に有効であることを確認している
[ ] `audio` がない場合に無効であることを確認している
[ ] 許可された `content_type` のとき有効であることを確認している
[ ] 不在な `content_type` のとき無効であることを確認している
[ ] サイズ制限を超える場合に無効であることを確認している
[ ] user / child に紐付くことを確認している
[ ] Recording モデルの spec がすべて通る