### PR TITLE
認証・ログイン周りのリクエストテストの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,8 @@ gem "sassc-rails"
 gem "kaminari", "1.2.2"
 gem "bootstrap5-kaminari-views"
 
+gem "rails-i18n"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,6 +333,9 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (8.1.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 8.0.0, < 9)
     railties (8.0.4)
       actionpack (= 8.0.4)
       activesupport (= 8.0.4)
@@ -523,6 +526,7 @@ DEPENDENCIES
   pry-rails
   puma (>= 5.0)
   rails (~> 8.0.3)
+  rails-i18n
   rspec-rails
   rubocop
   rubocop-rails

--- a/spec/requests/user_sessions_spec.rb
+++ b/spec/requests/user_sessions_spec.rb
@@ -1,24 +1,52 @@
 require 'rails_helper'
 
 RSpec.describe "UserSessions", type: :request do
-  describe "GET /new" do
-    it "returns http success" do
-      get "/user_sessions/new"
-      expect(response).to have_http_status(:success)
+  describe "POST /login" do
+    it "正しい情報でログインできる" do
+      user = create(:user, password: "password", password_confirmation: "password")
+      child = create(:child, user: user)
+
+      post login_path, params: {
+        email: user.email,
+        password: "password"
+      }
+
+      expect(response).to redirect_to(new_child_recording_path(child))
+    end
+
+    it "間違った情報ではログインできない" do
+      user = create(:user, password: "password", password_confirmation: "password")
+
+      post login_path, params: {
+        email: user.email,
+        password: "wrong_password"
+      }
+
+      expect(response).to have_http_status(:unprocessable_entity)
     end
   end
 
-  describe "GET /create" do
-    it "returns http success" do
-      get "/user_sessions/create"
-      expect(response).to have_http_status(:success)
+  describe "DELETE /logout" do
+    it "ログアウトできる" do
+      user = create(:user, password: "password", password_confirmation: "password")
+      child = create(:child, user: user)
+
+      post login_path, params: {
+        email: user.email,
+        password: "password"
+      }
+
+      delete logout_path
+
+      expect(response).to redirect_to(root_path)
     end
   end
 
-  describe "GET /destroy" do
-    it "returns http success" do
-      get "/user_sessions/destroy"
-      expect(response).to have_http_status(:success)
+  describe "認証が必要なページ" do
+    it "未ログインで設定画面にアクセスするとログイン画面にリダイレクトする"  do
+      get settings_path
+
+      expect(response).to redirect_to(login_path)
     end
   end
 end


### PR DESCRIPTION
## 概要
ログイン・ログアウトの主要フローに対するリクエストテストを追加する

## 対象ISSUE
close #131 

## 実装内容
- `spec/requests/user_sessions_spec.rb` を用意する
- 基本形を書く
- 骨組みを作る
- ログイン成功のテストを書く
- ログイン失敗のテストを書く
- ログイン後の遷移先を確認する
- ログアウトのテストを書く
- 未ログイン時のアクセス制限を書く
- spec を実行して通す

## 確認事項
- `spec/requests/user_sessions_spec.rb` を作成している
- 正しい情報でログインできることを確認している
⇒ 正常系で確認
- 間違った情報ではログインできないことを確認している
⇒ 異常系で確認
- ログイン成功時に期待する画面へ遷移することを確認している　
⇒ `redirect_to(new_child_recording_path(child))`
- ログアウトできることを確認している　
⇒ DELETE /logout
- ログイン時に保護された画面へアクセスした場合の挙動を確認している
⇒ `get settings_path`
- 認証まわりの request spec がすべて通る　
⇒ `$ docker compose exec web bundle exec rspec spec/requests/user_sessions_spec.rb`