### PR TITLE
ボタンのUI調整等

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,3 +7,4 @@
 @use 'user_edit';
 @use 'children';
 @use 'password_reset';
+@use 'users';

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -1,24 +1,114 @@
 /* ========================================
-   変数定義
+    変数定義
 ======================================== */
 :root {
-  /* カラーパレット */
-  --color-primary: #7FB77E; /* メインカラー（やさしい緑） */
-  --color-primary-light: #F7F4EF; /* 背景色（ベージュよりで柔らかく） */
-  --color-accent: #5C9D7A; /*アクセント（少し深い緑）*/
-  --color-secondary: #D8D2C2; /* サブカラー（グレージュ） */
-  --color-secondary-hover: #C9C3B4;
-  --color-text: #3A3A3A; /* テキスト色 */
-  --color-text-light: #6B6B6B;
-  --color-text-lighter: #9A9A9A;
-  --color-white: #ffffff; /* ベース */
-  --color-border: #E5E1D8;
+  /* ======================================================
+       カラーパレット(新：大人グリーン)
+  =======================================================*/
+
+  /* メインカラー（ボタン・ヘッダー） */
+  --color-primary: #8FAF9A;
+
+  /* 背景色（白ベースに変更） */
+  --color-primary-light: #F4F7F3;
+
+  /*アクセント（ホバー用）*/
+  --color-accent: #6F8F7B;
+
+  /* テキスト */
+  --color-text: #3A3A3A;
+  --color-text-light: #7A7A7A;
+  --color-text-lighter: #A0A0A0;
+
+  /* ベース */
+  --color-white: #ffffff;
+
+  /* 枠線（少しグリーン寄りに） */
+  --color-border: #E5EAE4;
 
   /* フォント */
   --font-main: 'Zen Old Mincho', serif;
   --font-system: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 
-  /* スペーシング */
+  /* =======================================
+     共通ボタン設計
+  ======================================== */
+
+  .btn-primary-main,
+  .btn-secondary-main,
+  .btn-text-link {
+    font-family: var(--font-main);
+    transition: all 0.3s ease;
+  }
+
+  /* メインボタン */
+  .btn-primary-main {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 220px;
+    height: 48px;
+    padding: 0 24px;
+    border: none;
+    border-radius: 16px;
+    background-color: var(--color-primary);
+    color: var(--color-white);
+    font-size: 1rem;
+    text-decoration: none;
+    box-shadow: 0 4px 10px rgba(143, 175, 154, 0.22);
+  }
+
+  .btn-primary-main:hover {
+    background-color: var(--color-accent);
+  }
+
+  /* サブボタン */
+  .btn-secondary-main {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 220px;
+    height: 48px;
+    padding: 0 24px;
+    border: 1.5px solid var(--color-primary);
+    border-radius: 16px;
+    background-color: var(--color-white);
+    color: var(--color-primary);
+    font-size: 1rem;
+    text-decoration: none;
+  }
+
+  .btn-secondary-main:hover {
+    background-color: var(--color-primary-light);
+  }
+
+  /* テキストリンク */
+  .btn-text-link {
+    display: inline-block;
+    font-size: 0.95rem;
+    color: var(--color-text-light);
+    text-decoration: none;
+    margin-top: 12px;
+  }
+
+  .btn-text-link:hover {
+    text-decoration: underline;
+    color: var(--color-text);
+  }
+
+  /* ボタン並び */
+  .button-group-vertical {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+    margin-top: 24px;
+  }
+
+  /*======================================
+     スペーシング
+  ======================================= */
+
   --spacing-xs: 0.25rem;   /* 4px */
   --spacing-sm: 0.5rem;    /* 8px */
   --spacing-md: 1rem;      /* 16px */
@@ -33,8 +123,8 @@
   --breakpoint-xl: 1200px;
 }
 
-/* ============================B============
-   リセットCSS
+/* ========================================
+     リセットCSS
 ======================================== */
 * {
   margin: 0;
@@ -175,6 +265,17 @@ ul, ol {
   .nav-container {
     padding: var(--spacing-md) var(--spacing-lg);
   }
+}
+
+html, body {
+  width: 100%;
+  overflow-x: hidden;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 /* ========================================

--- a/app/assets/stylesheets/children.scss
+++ b/app/assets/stylesheets/children.scss
@@ -1,3 +1,131 @@
+/* ==============================================
+   children #new - 2ステップ目の子ども情報登録画面
+============================================== */
+#child-new-page {
+  background-color: var(--color-primary-light);
+  min-height: 100vh;
+  padding: var(--spacing-lg) var(--spacing-md);
+
+  .child-new-card {
+    max-width: 420px;
+    margin: 0 auto;
+    background-color: var(--color-white);
+    border-radius: 20px;
+    padding: var(--spacing-lg);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  }
+
+  .children-new-page-title {
+    font-size: 1.8rem;
+    text-align: center;
+    margin: var(--spacing-lg) auto 2rem;
+    color: var(--color-text);
+  }
+    .signup-stepper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 2rem;
+    }
+
+  .stepper-text {
+    font-size: 0.95rem;
+    color: var(--color-text-light);
+    margin-bottom: 0.8rem;
+    }
+
+  .stepper-track {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+  }
+
+  .step-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .step-circle {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    border: 1.5px solid var(--color-primary);
+    background-color: var(--color-white);
+  }
+
+  .step-item.active .step-circle,
+  .step-item.completed .step-circle {
+    background-color: var(--color-primary);
+    border-color: var(--color-primary);
+  }
+
+  .step-line {
+    width: 32px;
+    height: 1.5px;
+    background-color: var(--color-primary);
+    margin: 0;
+  }
+
+  .confirm-card {
+    background-color: var(--color-white);
+    border: 1px solid var(--color-border);
+    border-radius: 16px;
+    padding: var(--spacing-lg);
+  }
+
+  .confirm-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: var(--spacing-lg);
+  }
+
+  .confirm-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .confirm-label {
+    font-size: 0.95rem;
+    color: var(--color-text-light);
+  }
+
+  .confirm-value {
+    font-size: 1rem;
+    color: var(--color-text);
+  }
+
+  .confirm-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-md);
+    margin-top: var(--spacing-lg);
+  }
+
+  .date-field {
+    text-align: left;
+    padding-left: 16px;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
+  .date-field::-webkit-date-and-time-value {
+    text-align: left;
+  }
+
+  .date-field::-webkit-datetime-edit {
+    text-align: left;
+    color: var(--color-text);
+  }
+}
+
+/* ==============================================
+   children #edit - 子ども情報編集画面
+============================================== */
 #child-edit-page {
   background-color: var(--color-primary-light);
   min-height: 100vh;

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -25,16 +25,69 @@
    _header_main 用のスタイル
 ======================================== */
 .header-main .nav-container {
-  justify-content: space-between; /* 左右に配置 */
-}
-
-/* ヘッダーの左・中央・右 */
-.header-left,
-.header-center,
-.header-right {
   display: flex;
   align-items: center;
-  gap: var(--spacing-sm);
+  justify-content: space-between; /* 左右に配置 */
+  width: 100%;
+}
+
+/* 左右の幅をそろえる */
+.header-left,
+.header-right {
+  flex: 0 0 88px;
+  display: flex;
+  align-items: center;
+}
+
+/* 左は左寄せ */
+.header-left {
+  justify-content: flex-start;
+}
+
+/* 右は右寄せ */
+.header-right {
+  justify-content: flex-end;
+}
+
+/* 中央は残りの幅の真ん中 */
+.header-center {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.logo-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  color: inherit;
+}
+
+.logo-wrapper {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  width: auto;
+  position: static;
+}
+
+.logo-image {
+  width: 42px;
+  height: 42px;
+  object-fit: contain;
+  position: static;
+  transform: none;
+  margin: 0;
+}
+
+.app-name {
+  font-size: 1.75rem;
+  font-weight: 500;
+  color: var(--color-white);
+  line-height: 1;
 }
 
 /* ========================================
@@ -67,8 +120,18 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.15rem;
+  gap: 2px;
   position: relative;
+  max-width: 88px;
+}
+
+.switcher-label,
+.selected-child-name {
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 88px;
 }
 
 .switcher-label {
@@ -281,12 +344,27 @@
 
 /* スマホ（〜767px） */
 @media (max-width: 767px) {
+  .header-left,
+  .header-right {
+    flex: 0 0 76px;
+  }
+
+  .logo-image {
+    width: 36px;
+    height: 36px;
+  }
+
+  .app-name {
+    font-size: 1.2rem;
+  }
+
   .switcher-label {
     font-size: 9px;
   }
 
   .selected-child-name {
     font-size: 11px;
+    max-width: 76px;
   }
 
   .switcher-icon {

--- a/app/assets/stylesheets/recordings.scss
+++ b/app/assets/stylesheets/recordings.scss
@@ -17,22 +17,78 @@
 
   /* 子どもの名前 */
   .child-name {
-    font-size: 1.5rem;
+    text-align: center;
+    font-size: 1.8rem;
     color: var(--color-text);
-    margin-bottom: var(--spacing-xl);
+    margin-bottom: 2rem;
+    margin-top: 2rem;
   }
 
-  /* 録音開始画面 */
-  #start-recording {
-    width: 100%;
-    padding: var(--spacing-md);
+  /* ========================================
+      録音開始ボタン（丸型）
+  ======================================== */
+  .record-button-wrap {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin-top: 2.5rem;
+    background: transparent;
+    width: auto;
+  }
+
+  #start-recording.record-start-button {
     border: none;
-    border-radius: 16px;
-    background-color: var(--color-primary);
+    background: transparent;
+    padding: 0;
+    cursor: pointer;
+    -webkit-appearance: none;
+    appearance: none;
+    width: auto;
+    box-shadow: none;
+  }
+
+  .record-start-button-outer {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    background-color: #f3a79d; /* 外側の薄い赤 */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 6px 14px rgba(0, 0, 0, 0.08);
+  }
+
+  .record-start-button-inner {
+    width: 86px;
+    height: 86px;
+    border-radius: 50%;
+    background-color: #df633f; /* 内側の濃い赤 */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .record-start-button i {
+    font-size: 2.3rem;
     color: var(--color-white);
-    font-size: 1.5rem;
-    font-family: var(--font-main);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    line-height: 1;
+    display: block;
+  }
+
+  .record-start-button:hover .record-start-button-outer {
+    transform: scale(1.03);
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.12);
+  }
+
+  .record-start-button:active .record-start-button-outer {
+    transform: scale(0.98);
+  }
+
+  .record-start-label {
+    margin-top: 1rem;
+    font-size: 1rem;
+    color: var(--color-text);
   }
 
   /* 録音中 */
@@ -50,19 +106,57 @@
     margin-bottom: var(--spacing-lg);
   }
 
-  #stop-recording {
-    width: 100%;
-    padding: var(--spacing-md);
+  /* =============================================
+       停止ボタン（録音中）
+  ==============================================*/
+  .record-stop-button {
     border: none;
-    border-radius: 16px;
-    background-color: #e57373;
-    color: var(--color-white);
-    font-size: 1.125rem;
-    font-family: var(--font-main);
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+    background: transparent;
+    padding: 0;
+    cursor: pointer;
+    -webkit-appearance: none;
+    appearance: none;
   }
 
-  /* プレビュー */
+  .record-stop-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .record-stop-button-outer {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    background-color: #f3a79d; /* 薄い赤 */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 6px 14px rgba(0, 0, 0, 0.08);
+    animation: blink 2s infinite, pulse 2.2s ease-in-out infinite;
+  }
+
+  .record-stop-button-inner {
+    width: 86px;
+    height: 86px;
+    border-radius: 50%;
+    background-color: #df633f;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .record-stop-button i {
+    font-size: 2rem;
+    color: var(--color-white);
+  }
+
+  .record-stop-button:active .record-stop-button-outer {
+    transform: scale(0.96);
+  }
+
+  /* =====================================
+      プレビュー画面
+  ======================================*/
   #preview-area {
     background-color: var(--color-white);
     border-radius: 20px;
@@ -127,27 +221,53 @@
     gap: var(--spacing-sm);
   }
 
-  #save-recording-form input[type="submit"] {
-    width: 100%;
-    padding: var(--spacing-md);
-    border: none;
-    border-radius: 16px;
-    background-color: var(--color-primary);
-    color: var(--color-white);
-    font-size: 1rem;
-    font-family: var(--font-main);
+  /* ====================================
+      プレビュー画面のボタン調整
+  =====================================*/
+  .preview-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 18px;
+    margin-top: 28px;
   }
 
-  #save-recording-form button[type="button"] {
-    width: 100%;
-    padding: var(--spacing-md);
-    border: 1px solid var(--color-border);
-    border-radius: 16px;
-    background-color: var(--color-white);
-    color: var(--color-text-light);
-    font-size: 1rem;
+  #save-recording-form .preview-save-button {
+    width: 260px;
+    max-width: 100%;
+    height: 56px;
+    padding: 0;
+    border-radius: 20px;
+    background-color: var(--color-primary);
+    color: var(--color-white);
+    font-size: 1.05rem;
     font-family: var(--font-main);
+    box-shadow: 0 6px 14px rgba(143, 175, 154, 0.18);
   }
+
+  .preview-back-link {
+    background: none;
+    border: none;
+    padding: 0;
+    width: auto;
+    height: auto;
+    color: var(--color-text-light);
+    font-size: 0.95rem;
+    font-family: var(--font-main);
+    cursor: pointer;
+    text-decoration: none;
+    box-shadow: none;
+    align-self: center;
+  }
+
+  .preview-back-link:hover {
+    opacity: 0.7;
+  }
+
+  .preview-back-link:active {
+    opacity: 0.5;
+  }
+
 
   /* エラーメッセージ・成功メッセージ */
   #success-messages,
@@ -174,9 +294,7 @@
 
   /* スマホ微調整 */
   @media (max-width: 767px) {
-    #recording-page {
-      padding: var(--spacing-md);
-    }
+    padding: var(--spacing-md);
 
     .child-name {
       font-size: 1.25rem
@@ -195,11 +313,27 @@
   }
 }
 
-/* 録音中点滅 */
+/* 録音中点滅 blink → 透明度が変わる*/
 @keyframes blink {
-  0%   { opacity: 1; }
-  50%  { opacity: 0.4; }
+  0% { opacity: 1; }
+  50% { opacity: 0.4; }
   100% { opacity: 1; }
+}
+
+/* 録音中 pulse → 少し大きくふわっとなる */
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.05);
+    opacity: 0.75;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
 }
 
 /* ========================================

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -46,25 +46,25 @@
 }
 
 .button-group .btn-primary {
-  background-color: #7BA3C0;
+  background-color: var(color-primary);
   border: none;
   color: var(--color-white);
 }
 
 .button-group .btn-primary:hover {
-  background-color: #6A8AAD;
+  background-color: var(--color-accent);
   transform: translateY(-2px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
 
 .button-group .btn-secondary {
-  background-color: var(--color-secondary);
-  border: none;
-  color: var(--color-text);
+  background-color: transparent;
+  border: 1px solid var(--color-primary);
+  color: var(--color-primary);
 }
 
 .button-group .btn-secondary:hover {
-  background-color: var(--color-secondary-hover);
+  background-color: var(--color-primary-light);
   transform: translateY(-2px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,142 @@
+/* ========================================
+   users #new - 1ステップ目のアカウント登録画面
+======================================== */
+#user-new-page {
+  background-color: var(--color-primary-light);
+  min-height: 100vh;
+  padding: var(--spacing-lg) var(--spacing-md);
+
+  .user-new-card {
+    max-width: 420px;
+    margin: 0 auto;
+    background-color: var(--color-white);
+    border-radius: 20px;
+    padding: var(--spacing-lg);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  }
+
+    .user-new-page-title {
+    font-size: 1.8rem;
+    text-align: center;
+    margin: var(--spacing-lg) auto 2rem;
+    color: var(--color-text);
+  }
+
+  .signup-stepper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 2rem;
+    }
+
+  .stepper-text {
+    font-size: 0.95rem;
+    color: var(--color-text-light);
+    margin-bottom: 0.8rem;
+    }
+
+  .stepper-track {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+  }
+
+  .step-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .step-circle {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    border: 1.5px solid var(--color-primary);
+    background-color: var(--color-white);
+  }
+
+  .step-item.active .step-circle {
+    background-color: var(--color-primary);
+  }
+
+  .step-line {
+    width: 32px;
+    height: 1.5px;
+    background-color: var(--color-primary);
+    margin: 0;
+  }
+
+  .step-label {
+    display: none;
+  }
+}
+
+/* ===================================================
+   users #confirm - 1ステップ目のアカウント情報確認画面
+====================================================== */
+#user-confirm-page {
+  background-color: var(--color-primary-light);
+  min-height: 100vh;
+  padding: var(--spacing-lg) var(--spacing-md);
+
+  .user-confirm-card {
+    max-width: 420px;
+    margin: 0 auto;
+    background-color: var(--color-white);
+    border-radius: 20px;
+    padding: var(--spacing-lg);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  }
+
+  .confirm-page-title {
+    text-align: center;
+    margin: var(--spacing-lg) auto var(--spacing-sm);
+    color: var(--color-text);
+    font-size: 1.8rem;
+  }
+
+  .confirm-subtitle {
+    text-align: center;
+    color: var(--color-text-light);
+    margin-bottom: var(--spacing-xl);
+    font-size: 0.95rem;
+  }
+
+  .confirm-card {
+    background-color: var(--color-bg-soft, #F4F7F3);
+    border-radius: 16px;
+    padding: var(--spacing-lg);
+  }
+
+  .confirm-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .confirm-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .confirm-label {
+    font-size: 0.95rem;
+    color: var(--color-text-light);
+  }
+
+  .confirm-value {
+    font-size: 1rem;
+    color: var(--color-text);
+    word-break: break-word;
+  }
+
+  .confirm-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-md);
+    margin-top: var(--spacing-xl);
+  }
+}

--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -9,7 +9,8 @@ class ChildrenController < ApplicationController
     end
     # 一時的な User オブジェクトを作成（DB には保存しない）
     @user = User.new(session[:user_params])
-    @child = @user.children.build
+    @user.children.build if @user.children.empty?
+    # @child = @user.children.build
   end
 
   def create
@@ -20,12 +21,13 @@ class ChildrenController < ApplicationController
     end
 
     @user = User.new(session[:user_params])
-    @child = @user.children.build(child_params)
+    @user.assign_attributes(user_children_params)
+    # @child = @user.children.build(child_params)
 
     # トランザクションで両方を保存
     ActiveRecord::Base.transaction do
       @user.save!
-      @child.save!
+      # @child.save!
 
       # ログイン処理
       auto_login(@user)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,9 +11,25 @@ class UsersController < ApplicationController
   end
 
   def confirm
+    # ======================
+    # GETの場合（戻るボタン）
+    # ======================
+    if request.get?
+      unless session[:user_params]
+        flash[:alert] = "ユーザー情報が見つかりません"
+        redirect_to new_user_path
+        return
+      end
+
+      @user = User.new(session[:user_params])
+      return
+    end
+
+    # =========================
+    # POSTの場合（次へボタン）
+    # =========================
     @user = User.new(user_params)
 
-    # バリデーションチェック
     if @user.valid?
       # sessionに一時保存
       session[:user_params] = user_params.to_h

--- a/app/javascript/src/recordings.js
+++ b/app/javascript/src/recordings.js
@@ -48,8 +48,36 @@ document.addEventListener('turbo:load', () => {
   const recordingDuration = document.getElementById('recording-duration');
   const saveForm = document.getElementById('save-recording-form');
   const durationField = document.getElementById('duration-field');
+  const backToInitialButton = document.getElementById('back-to-initial');
 
   if (!startButton || !stopRecordingButton || !recordingDuration) return;
+
+  if (backToInitialButton) {
+    backToInitialButton.addEventListener('click', () => {
+      const audioPlayer = document.getElementById('audio-player');
+      const seekBar = document.getElementById('seek-bar');
+      const currentTime = document.getElementById('current-time');
+      const previewDuration = document.getElementById('preview-duration');
+
+      if (audioPlayer) {
+        audioPlayer.pause();
+        audioPlayer.currentTime = 0;
+        audioPlayer.src = '';
+      }
+
+      if (seekBar) seekBar.value = 0;
+      if (currentTime) currentTime.textContent = '00:00';
+      if (previewDuration) previewDuration.textContent = '00:00';
+      if (durationField) durationField.value = '';
+
+      recordedAudioBlob = null;
+      audioChunks = [];
+      recordingSeconds = 0;
+      updateTimer(0);
+
+      showScreen('initial-screen');
+    });
+  }
 
   let audioControlsInitialized = false;
   let mediaRecorder;
@@ -134,7 +162,6 @@ document.addEventListener('turbo:load', () => {
   });
 
   function showPreview(audioBlob) {
-    console.log("showPreview呼ばれた");
     recordedAudioBlob = audioBlob;
 
     const audioUrl = URL.createObjectURL(audioBlob);

--- a/app/views/children/new.html.erb
+++ b/app/views/children/new.html.erb
@@ -1,62 +1,61 @@
-<div class= "container">
-  <div class= "row">
-    <div class= "col-md-10 col-lg-8 mx-auto">
-      <h1 class="mb-4 text-center">お子さまの情報登録</h1>
+<div id="child-new-page">
+  <div class="child-new-card">
+    <h1 class="children-new-page-title">お子さま情報登録</h1>
 
-      <div class="mb-5">
-        <!-- ステップインジケーター -->
-        <div class="d-flex justify-content-between">
-          <div class="text-center text-muted">
-            <div class="badge bg-success">✓</div>
-            <div>アカウント情報</div>
-          </div>
-          <div class="text-center">
-            <div class="badge bg-primary">2</div>
-            <div>お子様情報</div>
-          </div>
+    <!-- ステップインジケーター -->
+    <div class="signup-stepper">
+      <p class="stepper-text">ステップ 2/2</p>
+
+      <div class="stepper-track">
+        <div class="step-item completed">
+          <span class="step-circle"></span>
+        </div>
+
+        <div class="step-line"></div>
+
+        <div class="step-item active">
+          <span class="step-circle"></span>
         </div>
       </div>
+    </div>
 
-      <%= form_with model: @user, url: children_path, method: :post, local: true do |f| %>
-        <div id="children-fields">
-          <%= f.fields_for :children do |child_form| %>
-            <div class="child-fields mb-4">
-              <div class="mb-3">
-                <%= child_form.label :name, class: "form-label" %>
-                <%= child_form.text_field :name, class: "form-control" %>
+    <%= form_with model: @user, url: children_path, method: :post, local: true do |f| %>
+      <div id="children-fields">
+        <%= f.fields_for :children do |child_form| %>
+          <div class="child-fields mb-4">
+            <div class="mb-3">
+              <%= child_form.label :name, class: "form-label" %>
+              <%= child_form.text_field :name, class: "form-control" %>
 
-          <% if child_form.object.errors[:name].any? %>
-            <div class="errors-message">
-              <%= child_form.object.errors.full_messages_for(:name).join(", ") %>
+              <% if child_form.object.errors[:name].any? %>
+                <div class="errors-message">
+                  <%= child_form.object.errors.full_messages_for(:name).join(", ") %>
+                </div>
+              <% end %>
             </div>
-          <% end %>
-        </div>
 
-        <div class="mb-3">
-          <%= child_form.label :birthday, class: "form-label" %>
-          <%= child_form.date_field :birthday, class: "form-control" %>
+            <div class="mb-3">
+              <%= child_form.label :birthday, class: "form-label" %>
+              <%= child_form.date_field :birthday, class: "form-control date-field" %>
 
-          <% if child_form.object.errors[:birthday].any? %>
-            <div class= "errors-message">
-              <%= child_form.object.errors.full_messages_for(:birthday).join(", ") %>
+              <% if child_form.object.errors[:birthday].any? %>
+                <div class= "errors-message">
+                  <%= child_form.object.errors.full_messages_for(:birthday).join(", ") %>
+                </div>
+              <% end %>
             </div>
-          <% end %>
-        </div>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="mb-4 text-center">
+        <button type="button" id="add-child-button" class="btn-secondary-main">
+          + お子さまを追加
+        </button>
+
+        <%= f.submit "登録完了", class: "btn-primary-main" %>
+        <%= link_to "← もどる", confirm_users_path, class: "btn-text-link" %>
       </div>
     <% end %>
-  </div>
-
-  <div class="mb-4 text-center">
-    <button type="button" id="add-child-button" class="btn btn-outline-success">
-      [ + お子さまを追加 ]
-    </button>
-  </div>
-
-  <div class="button-group">
-          <%= f.submit "[ 登録完了 ]", class: "btn btn-primary" %>
-          <%= link_to "[ 戻る ]", new_user_path, class: "btn btn-secondary" %>
-        </div>
-      <% end %>
-    </div>
   </div>
 </div>

--- a/app/views/recordings/new.html.erb
+++ b/app/views/recordings/new.html.erb
@@ -7,22 +7,41 @@
     <div class="child-name">
       <%= @child.name %>
     </div>
-    <button id="start-recording" class="btn btn-primary">
-    録音をはじめる
-    </button>
+
+    <div class="record-button-wrap">
+      <button id="start-recording" class="record-start-button" type="button">
+        <span class="record-start-button-outer">
+          <span class="record-start-button-inner">
+            <i class="fa-solid fa-microphone"></i>
+          </span>
+        </span>
+      </button>
+
+      <p class="record-start-label">タップして録音開始</p>
+    </div>
   </div>
 
   <!-- 録音中画面 -->
   <div id="recording-screen" style="display:none;">
     <div class="recording-now">
-    録音中……
+      録音中……
     </div>
+
     <div class="recording-time">
       <span id="recording-duration">00:00</span>
     </div>
-    <button id="stop-recording" class="btn btn-danger" disabled>
-    停止
-    </button>
+
+    <div class="record-button-wrap">
+      <button id="stop-recording" class="record-stop-button" type="button" disabled>
+        <span class="record-stop-button-outer">
+          <span class="record-stop-button-inner">
+            <i class="fa-solid fa-stop"></i>
+          </span>
+        </span>
+      </button>
+
+      <p class="record-start-label">タップして停止</p>
+    </div>
   </div>
 
   <!-- プレビュー画面 -->
@@ -61,9 +80,11 @@
     <%= f.hidden_field :title, value: "無題", id: 'title-field' %>
     <%= f.hidden_field :duration, id: "duration-field" %>
 
-    <div class="form-actions">
-      <%= f.submit "保存", class: "btn btn-success", id: "save-button" %>
-      <button type="button", class="btn btn-secondary" onclick="history.back()">戻る</button>
+    <div class="form-actions preview-actions">
+      <%= f.submit "保存", class: "btn-primary-main preview-save-button", id: "save-button" %>
+      <button type="button" class="btn-text-link preview-back-link" id="back-to-initial">
+        ← もどる
+      </button>
     </div>
   <% end %>
 </div>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -6,8 +6,8 @@
       <div class="mb-5">
 
         <div class="button-group">
-          <%= link_to "[ 新規登録 ]", new_user_path, class: "btn btn-primary" %>
-          <%= link_to "[ ログイン ]", login_path, class: "btn btn-secondary" %>
+          <%= link_to "新規登録", new_user_path, class: "btn-primary-main" %>
+          <%= link_to "ログイン", login_path, class: "btn-secondary-main" %>
         </div>
 
         <div class="description">

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -14,10 +14,10 @@
           <%= f.label :password, class: "form-label" %>
           <%= f.password_field :password, class: "form-control", required: true %>
         </div>
-        
+
         <div class="button-group">
-          <%= f.submit "[ ログイン ]", class: "btn btn-primary" %>
-          <%= link_to "[ 戻る ]", root_path, class: "btn btn-secondary" %>
+          <%= f.submit "ログイン", class: "btn-primary-main" %>
+          <%= link_to "← もどる", root_path, class: "btn-text-link" %>
         </div>
       <% end %>
     </div>

--- a/app/views/users/confirm.html.erb
+++ b/app/views/users/confirm.html.erb
@@ -1,37 +1,24 @@
-<div class="container">
-  <div class="row">
-    <div class="col-md-10 col-lg-8 mx-auto">
-      <h1 class="mt-4 mb-4 text-center">登録内容の確認</h1>
+<div id="user-confirm-page">
+  <div class="user-confirm-card">
+    <h1 class="confirm-page-title">登録内容の確認</h1>
+    <p class="confirm-subtitle">入力内容をご確認ください</p>
 
-      <div class="mb-5">
-        <!-- ステップインジケーター -->
-        <div class="d-flex justify-content-between">
-          <div class="text-center text-muted">
-            <div class="badge bg-secondary">1</div>
-            <div>アカウント情報</div>
-          </div>
-          <div class="text-center">
-            <div class="badge bg-primary">2</div>
-            <div>確認</div>
-          </div>
+    <div class="confirm-card">
+      <div class="confirm-list">
+        <div class="confirm-row">
+          <span class="confirm-label">お名前</span>
+          <span class="confirm-value"><%= @user.name %></span>
+        </div>
+
+        <div class="confirm-row">
+          <span class="confirm-label">メールアドレス</span>
+          <span class="confirm-value"><%= @user.email %></span>
         </div>
       </div>
 
-      <div class="card">
-        <div class="card-body">
-          <dl class="row">
-            <dt class="col-sm-3">名前</dt>
-            <dd class="col-sm-9"><%= @user.name %></dd>
-
-            <dt class="col-sm-3">メールアドレス</dt>
-            <dd class="col-sm-9"><%= @user.email %></dd>
-          </dl>
-
-          <div class="d-flex justify-content-between mt-4">
-            <%= link_to "[ 戻る ]", new_user_path, class: "btn btn-secondary" %>
-            <%= link_to "[ お子様登録へ進む ]", new_child_path, class: "btn btn-primary" %>
-          </div>
-        </div>
+      <div class="confirm-actions">
+        <%= link_to "お子さま登録へ進む", new_child_path, class: "btn-primary-main" %>
+        <%= link_to "← もどる", new_user_path, class: "btn-text-link" %>
       </div>
     </div>
   </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,73 +1,72 @@
-<div class= "container">
-  <div class= "row">
-    <div class= "col-md-10 col-lg-8 mx-auto">
-      <h1 class="mt-4 mb-4 text-center">アカウント情報</h1>
+<div id="user-new-page">
+  <div class="user-new-card">
+    <h1 class="user-new-page-title">アカウント登録</h1>
+    <!-- ステップインジケーター -->
+    <div class="signup-stepper">
+      <p class="stepper-text">ステップ 1/2</p>
 
-      <div class="mb-5">
-        <!-- ステップインジケーター -->
-        <div class="d-flex juistify-content-between">
-          <div class="text-center">
-            <div class="badge bg-primary">1</div>
-            <div>アカウント情報</div>
-          </div>
-          <div class="text-center text-muted">
-            <div class="badge bg-secondary">2</div>
-            <div>お子様情報</div>
-          </div>
+      <div class="stepper-track">
+        <div class="step-item active">
+          <span class="step-circle"></span>
+        </div>
+
+        <div class="step-line"></div>
+
+        <div class="step-item">
+          <span class="step-circle"></span>
         </div>
       </div>
-
-      <%= form_with model: @user, url: confirm_users_path, method: :post, data: { turbo: false } do |f| %>
-
-        <div class="mb-3">
-          <%= f.label :name, class: "form-label" %>
-          <%= f.text_field :name, class: "form-control" %>
-
-          <% if @user.errors[:name].any? %>
-            <div class="error-message">
-              <%= @user.errors.full_messages_for(:name).join(", ") %>
-            </div>
-          <% end %>
-        </div>
-
-        <div class="mb-3">
-          <%= f.label :email, class: "form-label" %>
-          <%= f.email_field :email, class: "form-control" %>
-
-          <% if @user.errors[:email].any? %>
-            <div class="error-message">
-              <%= @user.errors.full_messages_for(:email).join(", ") %>
-            </div>
-          <% end %>
-        </div>
-
-        <div class="mb-3">
-          <%= f.label :password, class: "form-label" %>
-          <%= f.password_field :password, class: "form-control" %>
-
-          <% if @user.errors[:password].any? %>
-            <div class="error-message">
-              <%= @user.errors.full_messages_for(:password).join(", ") %>
-            </div>
-          <% end %>
-        </div>
-
-        <div class="mb-3">
-          <%= f.label :password_confirmation, class: "form-label" %>
-          <%= f.password_field :password_confirmation, class: "form-control" %>
-
-          <% if @user.errors[:password_confirmation].any? %>
-            <div class="error-message">
-              <%= @user.errors.full_messages_for(:password_confirmation).join(", ") %>
-            </div>
-          <% end %>
-        </div>
-
-        <div class="button-group">
-          <%= f.submit "[ 次へ ]", class: "btn btn-primary" %>
-          <%= link_to "[ 戻る ]", root_path, class: "btn btn-secondary" %>
-        </div>
-      <% end %>
     </div>
+
+    <%= form_with model: @user, url: confirm_users_path, method: :post, data: { turbo: false } do |f| %>
+      <div class="mb-3">
+        <%= f.label :name, class: "form-label" %>
+        <%= f.text_field :name, class: "form-control" %>
+
+        <% if @user.errors[:name].any? %>
+          <div class="error-message">
+            <%= @user.errors.full_messages_for(:name).join(", ") %>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :email, class: "form-label" %>
+        <%= f.email_field :email, class: "form-control" %>
+
+        <% if @user.errors[:email].any? %>
+          <div class="error-message">
+            <%= @user.errors.full_messages_for(:email).join(", ") %>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :password, class: "form-label" %>
+        <%= f.password_field :password, class: "form-control" %>
+
+        <% if @user.errors[:password].any? %>
+          <div class="error-message">
+            <%= @user.errors.full_messages_for(:password).join(", ") %>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :password_confirmation, class: "form-label" %>
+        <%= f.password_field :password_confirmation, class: "form-control" %>
+
+        <% if @user.errors[:password_confirmation].any? %>
+          <div class="error-message">
+            <%= @user.errors.full_messages_for(:password_confirmation).join(", ") %>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="button-group-vertical">
+        <%= f.submit "次へ", class: "btn-primary-main" %>
+        <%= link_to "← もどる", root_path, class: "btn-text-link" %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   # ユーザー登録
   resources :users, only: %i[new] do
     collection do
+      get :confirm
       post :confirm # 確認用アクション
     end
   end


### PR DESCRIPTION
## 概要
ボタンのUI調整等

## 対象ISSUE
close #151

## 修正内容
- [保存], [もどる], [次へ] 等の各ボタンのUI仕様を変更
- アプリ全体のテーマカラーをカジュアルめ→大人上品な落ち着いた印象に変更
- 録音画面の[録音ボタン],[停止ボタン] にデザインをあて、使用中のアクションもscssで設定 
- ヘッダー部分アプリ名＆ログの配置を中央に修正

