### PR TITLE
シークバーのスタイルを当て直した

### DIFF
--- a/app/assets/stylesheets/recordings.scss
+++ b/app/assets/stylesheets/recordings.scss
@@ -184,6 +184,58 @@
   #seek-bar {
     width: 100%;
     margin-bottom: var(--spacing-sm);
+    -webkit-appearance: none;
+    appearance: none;
+    background: transparent;
+    height: 24px;
+    cursor: pointer;
+  }
+
+  /* Chrome / Safari / Edge */
+  #seek-bar::-webkit-slider-runnable-track {
+    height: 8px;
+    border-radius: 999px;
+    background: linear-gradient(
+      to right,
+      #9AA89A 0%,
+      #9AA89A var(--progress, 0%),
+      #D9DED9 var(--progress, 0%),
+      #D9DED9 100%
+    );
+  }
+
+  #seek-bar::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background: #ffffff;
+    border: 1px solid #D5D9D5;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    margin-top: -9px; /* track中央に合わせる */
+  }
+
+  /* Firefox */
+  #seek-bar::-moz-range-track {
+    height: 8px;
+    border-radius: 999px;
+    background: #D9DED9;
+  }
+
+  #seek-bar::-moz-range-progress {
+    height: 8px;
+    border-radius: 999px;
+    background: #9AA89A;
+  }
+
+  #seek-bar::-moz-range-thumb {
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background: #ffffff;
+    border: 1px solid #D5D9D5;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
   }
 
   .current-time {
@@ -388,7 +440,7 @@
   }
 
   .detail-comment {
-    border: 1px solid var(--spacing-border);
+    border: 1px solid var(--color-border);
     border-radius: 12px;
     padding: var(--spacing-md);
     background-color: #faf9f6;
@@ -446,62 +498,66 @@
     text-align: left;
   }
 
-  /*
-  .recording-meta {
-    width: 100%;
-    text-align: left;
-  }
-
-  .recording-meta p {
-    margin: 0;
-  }
-
-  .recording-date-value {
-    font-size: 1.1rem;
-    color: var(--color-text);
-    font-weight: bold;
-    line-height: 1.2;
-    text-align: left;
-    margin-bottom: 2px;
-  }
-
-  .recording-age-text {
-    font-size: 0.9rem;
-    color: var(--color-text-light);
-    line-height: 1.2;
-    text-align: left;
-  }
-  */
-
   .seek-bar-area {
     width: 100%;
     margin-bottom: var(--spacing-lg);
   }
 
+   /* 再生バー */
   #seek-bar {
     width: 100%;
-    display: block;
     margin-bottom: var(--spacing-sm);
     -webkit-appearance: none;
     appearance: none;
     background: transparent;
+    height: 24px;
+    cursor: pointer;
   }
 
+  /* Chrome / Safari / Edge */
   #seek-bar::-webkit-slider-runnable-track {
-    height: 6px;
-    background-color: var(--color-border);
+    height: 8px;
     border-radius: 999px;
+    background: linear-gradient(
+      to right,
+      #9AA89A 0%,
+      #9AA89A var(--progress, 0%),
+      #D9DED9 var(--progress, 0%),
+      #D9DED9 100%
+    );
   }
 
   #seek-bar::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
-    width: 22px;
-    height: 22px;
-    margin-top: -8px;
+    width: 26px;
+    height: 26px;
     border-radius: 50%;
-    background-color: var(--color-white);
-    border: 1px solid var(--color-border);
+    background: #ffffff;
+    border: 1px solid #D5D9D5;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    margin-top: -9px; /* track中央に合わせる */
+  }
+
+  /* Firefox */
+  #seek-bar::-moz-range-track {
+    height: 8px;
+    border-radius: 999px;
+    background: #D9DED9;
+  }
+
+  #seek-bar::-moz-range-progress {
+    height: 8px;
+    border-radius: 999px;
+    background: #9AA89A;
+  }
+
+  #seek-bar::-moz-range-thumb {
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background: #ffffff;
+    border: 1px solid #D5D9D5;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
   }
 

--- a/app/javascript/src/recording_show.js
+++ b/app/javascript/src/recording_show.js
@@ -13,6 +13,11 @@ document.addEventListener('turbo:load', () => {
     return;
   }
 
+  function updateSeekBarProgress(seekBar) {
+    const value = seekBar.value || 0;
+    seekBar.style.setProperty('--progress', `${value}%`);
+  }
+
   console.log('show page audio controls initialized');
 
   playToggleButton.addEventListener('click', async () => {
@@ -32,6 +37,7 @@ document.addEventListener('turbo:load', () => {
   audioPlayer.addEventListener('ended', () => {
     playIcon.classList.replace('fa-pause', 'fa-play');
     seekBar.value = 0;
+    updateSeekBarProgress(seekBar);
     currentTime.textContent = '00:00';
   });
 
@@ -40,6 +46,7 @@ document.addEventListener('turbo:load', () => {
 
     const progress = (audioPlayer.currentTime / audioPlayer.duration) * 100;
     seekBar.value = progress;
+    updateSeekBarProgress(seekBar);
 
     const minutes = Math.floor(audioPlayer.currentTime / 60).toString().padStart(2, '0');
     const seconds = Math.floor(audioPlayer.currentTime % 60).toString().padStart(2, '0');
@@ -51,5 +58,8 @@ document.addEventListener('turbo:load', () => {
 
     const seekTime = audioPlayer.duration * (seekBar.value / 100);
     audioPlayer.currentTime = seekTime;
+    updateSeekBarProgress(seekBar);
   });
+
+  updateSeekBarProgress(seekBar);
 });

--- a/app/javascript/src/recordings.js
+++ b/app/javascript/src/recordings.js
@@ -93,6 +93,11 @@ document.addEventListener('turbo:load', () => {
 
   showScreen('initial-screen');
 
+  function updateSeekBarProgress(seekBar) {
+    const value = seekBar.value || 0;
+    seekBar.style.setProperty('--progress', `${value}%`);
+  }
+
   function updateTimer(seconds) {
     const minutes = Math.floor(seconds / 60).toString().padStart(2, '0');
     const secs = (seconds % 60).toString().padStart(2, '0');
@@ -260,6 +265,7 @@ document.addEventListener('turbo:load', () => {
     audioPlayer.addEventListener('ended', () => {
       playIcon.classList.replace('fa-pause', 'fa-play');
       seekBar.value = 0;
+      updateSeekBarProgress(seekBar);
       currentTime.textContent = '00:00';
     });
 
@@ -268,6 +274,7 @@ document.addEventListener('turbo:load', () => {
 
       const progress = (audioPlayer.currentTime / audioPlayer.duration) * 100;
       seekBar.value = progress;
+      updateSeekBarProgress(seekBar);
 
       const minutes = Math.floor(audioPlayer.currentTime / 60).toString().padStart(2, '0');
       const seconds = Math.floor(audioPlayer.currentTime % 60).toString().padStart(2, '0');
@@ -279,7 +286,11 @@ document.addEventListener('turbo:load', () => {
 
       const seekTime = audioPlayer.duration * (seekBar.value / 100);
       audioPlayer.currentTime = seekTime;
+
+      updateSeekBarProgress(seekBar);
     });
+
+    updateSeekBarProgress(seekBar);
   }
 
   setupFormSubmit();


### PR DESCRIPTION
## 概要
プレビュー画面と詳細画面に表示されるシークバーが、再生時正常な動作をしなかったため追加ISSUEで修正する

## 対象ISSUE
close #155 

## 実装内容
- PC・スマホ療法で同じ見た目のシークバーにしたいため、PCブラウザ標準の仕様にせず自分でスタイルを当てる
- JavaScript ファイルを修正
- `updateSeekBarProgress` 関数を定義
- `update`, `input`, `ended` にそれぞれシークバーの更新処理を追加

