### PR TITLE
Feature/159 footer

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,3 +9,4 @@
 @use 'password_reset';
 @use 'users';
 @use 'user_sessions';
+@use 'static_pages';

--- a/app/assets/stylesheets/static_pages.scss
+++ b/app/assets/stylesheets/static_pages.scss
@@ -1,0 +1,57 @@
+#terms-page {
+  background-color: var(--color-primary-light);
+  min-height: 100vh;
+  padding: 48px 16px 32px;
+
+  .terms-title {
+    margin-top: 24px;
+    margin-bottom: 24px;
+  }
+}
+
+#contact-page {
+  background-color: var(--color-primary-light);
+  min-height: 100vh;
+  padding: 48px 16px 32px;
+
+  .contact-title {
+    margin-top: 24px;
+    margin-bottom: 24px;
+  }
+
+  .contact-box {
+    background-color: #F7F4EF;
+    border: 1px solid var(--color-border);
+    border-radius: 16px;
+    padding: 20px;
+    margin-bottom: 24px;
+  }
+
+  .contact-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 20px;
+  border-radius: 12px;
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
+  }
+
+  .contact-btn:hover {
+    background-color: var(--color-accent);
+  }
+}
+
+#privacy-page {
+  background-color: var(--color-primary-light);
+  min-height: 100vh;
+  padding: 48px 16px 32px;
+
+  .privacy-title {
+    margin-top: 24px;
+    margin-bottom: 24px;
+  }
+}

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,12 @@
+class StaticPagesController < ApplicationController
+  skip_before_action :require_login
+
+  def terms
+  end
+
+  def privacy
+  end
+
+  def contact
+  end
+end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,18 +1,15 @@
 <footer class="footer">
   <nav class="nav-container">
     <div class="footer-left">
-      <!-- パスは後ほど利用規約へのパスに変更 -->
-      <%= link_to "利用規約", root_path, class: "footer-link" %>
+      <%= link_to "利用規約", terms_path, class: "footer-link", data: { turbo: false } %>
     </div>
 
     <div class="footer-center">
-      <!-- パスは後ほどプライバシーポリシーへのパスに変更 -->
-      <%= link_to "プライバシーポリシー", root_path, class: "footer-link" %>
+      <%= link_to "プライバシーポリシー", privacy_path, class: "footer-link", data: { turbo: false } %>
     </div>
 
     <div class="footer-right">
-      <!-- パスは後ほどお問い合わせへのパスに変更 -->
-      <%= link_to "お問い合わせ", root_path, class: "footer-link" %>
+      <%= link_to "お問い合わせ", contact_path, class: "footer-link", data: { turbo: false } %>
     </div>
   </nav>
 </footer>

--- a/app/views/static_pages/contact.html.erb
+++ b/app/views/static_pages/contact.html.erb
@@ -1,0 +1,25 @@
+<div id="contact-page">
+  <div class="container">
+    <h1 class="contact-title">お問い合わせ</h1>
+
+    <div class="contact-content">
+      <p class="mb-6">
+        サービスに関するご質問やご意見がございましたら、以下のフォームよりお問い合わせください。
+      </p>
+
+      <div class="contact-box">
+        <p class="mb-4">
+          お問い合わせは、下記のGoogleフォームより承っております。
+        </p>
+        <%= link_to "お問い合わせフォームを開く", "https://forms.gle/gkX3cvNXJQbZLNnM7",
+                    target: "_blank",
+                    class: "contact-btn" %>
+      </div>
+
+      <div class="text-sm text-gray-600">
+        <p class="mb-2">※ Googleフォームが開きます</p>
+        <p>※ お問い合わせ内容によっては、回答までにお時間をいただく場合がございます</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,47 @@
+<div id="privacy-page">
+  <div class="container">
+    <h1 class="privacy-title">プライバシーポリシー</h1>
+
+    <div class="privacy-content">
+      <section class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4">個人情報の収集について</h2>
+        <p class="mb-4">
+          当サービスでは、ユーザー登録時にメールアドレス等の個人情報を収集します。
+          収集した個人情報は、サービスの提供・運営のために利用します。
+        </p>
+      </section>
+
+      <section class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4">個人情報の利用目的</h2>
+        <ul class="list-disc pl-6 mb-4">
+          <li>本サービスの提供・運営のため</li>
+          <li>利用者からのお問い合わせに回答するため</li>
+          <li>利用規約に違反した利用者や、不正・不当な目的でサービスを利用しようとする利用者の特定をし、ご利用をお断りするため</li>
+          <li>上記の利用目的に付随する目的</li>
+        </ul>
+      </section>
+
+      <section class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4">個人情報の第三者提供</h2>
+        <p class="mb-4">
+          当サービスは、利用者の同意を得ることなく、第三者に個人情報を提供することはありません。
+          ただし、法令に基づく場合を除きます。
+        </p>
+      </section>
+
+      <section class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4">個人情報の安全管理</h2>
+        <p class="mb-4">
+          当サービスは、個人情報の漏洩、滅失またはき損の防止その他の個人情報の安全管理のために必要かつ適切な措置を講じます。
+        </p>
+      </section>
+
+      <section class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4">プライバシーポリシーの変更</h2>
+        <p class="mb-4">
+          本ポリシーの内容は、法令その他本ポリシーに別段の定めのある事項を除いて、利用者に通知することなく変更することができるものとします。
+        </p>
+      </section>
+    </div>
+  </div>
+</div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,0 +1,34 @@
+<div id="terms-page">
+  <div class="container">
+    <h1 class="terms-title">利用規約</h1>
+
+    <div class="terms-content">
+      <section class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4">第1条(適用)</h2>
+        <p class="mb-4">
+          本規約は、本サービスの提供条件及び本サービスの利用に関する当社と利用者との間の権利義務関係を定めることを目的とし、
+          利用者と当社との間の本サービスの利用に関わる一切の関係に適用されます。
+        </p>
+      </section>
+
+      <section class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4">第2条(禁止事項)</h2>
+        <p class="mb-4">利用者は、本サービスの利用にあたり、以下の行為をしてはなりません。</p>
+        <ul class="list-disc pl-6 mb-4">
+          <li>法令または公序良俗に違反する行為</li>
+          <li>犯罪行為に関連する行為</li>
+          <li>本サービスの内容等、本サービスに含まれる著作権、商標権ほか知的財産権を侵害する行為</li>
+          <li>当社、ほかの利用者、またはその他第三者のサーバーまたはネットワークの機能を破壊したり、妨害したりする行為</li>
+          <li>その他、当社が不適切と判断する行為</li>
+        </ul>
+      </section>
+
+      <section class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4">第3条(免責事項)</h2>
+        <p class="mb-4">
+          当社は、本サービスに関して、利用者と他の利用者または第三者との間において生じた取引、連絡または紛争等について一切責任を負いません。
+        </p>
+      </section>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,11 @@ Rails.application.routes.draw do
   # 設定画面
   get "settings", to: "settings#show"
 
+  # フッター
+  get 'terms', to: 'static_pages#terms', as: 'terms'
+  get 'privacy', to: 'static_pages#privacy', as: 'privacy'
+  get 'contact', to: 'static_pages#contact', as: 'contact'
+
   resource :user, only: [] do
     get :edit_name
     patch :update_name

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "StaticPages", type: :request do
+  describe "GET /terms" do
+    it "returns http success" do
+      get "/static_pages/terms"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /privacy" do
+    it "returns http success" do
+      get "/static_pages/privacy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /contact" do
+    it "returns http success" do
+      get "/static_pages/contact"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/static_pages/contact.html.tailwindcss_spec.rb
+++ b/spec/views/static_pages/contact.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "static_pages/contact.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/static_pages/privacy.html.tailwindcss_spec.rb
+++ b/spec/views/static_pages/privacy.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "static_pages/privacy.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/static_pages/terms.html.tailwindcss_spec.rb
+++ b/spec/views/static_pages/terms.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "static_pages/terms.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
仮設置だったフッターにリンクを設定

## 対象ISSUE
close #159 

## 実装内容
- ルーティングの追加
- コントローラーの作成
- ビューファイル（各ページ）を作成
- フッターにリンクを追加
- CSS追加
- `application.scss` にscss の読み込み設定
- 動作確認

