### PR TITLE
エラーメッセージの表示形式を統一

### DIFF
--- a/app/assets/stylesheets/password_reset.scss
+++ b/app/assets/stylesheets/password_reset.scss
@@ -55,6 +55,26 @@
     border-color: var(--color-primary);
   }
 
+  .password-field-wrap {
+    position: relative;
+  }
+
+  .password-field-wrap .form-field {
+    padding-right: 48px;
+  }
+
+  .password-toggle-button {
+    position: absolute;
+    top: 50%;
+    right: 14px;
+    transform: translateY(-50%);
+    border: none;
+    background: none;
+    color: var(--color-text-light);
+    cursor: pointer;
+    padding: 4px;
+  }
+
   .actions {
     margin-top: 32px;
     text-align: center;

--- a/app/assets/stylesheets/recordings.scss
+++ b/app/assets/stylesheets/recordings.scss
@@ -882,10 +882,18 @@
 
   .home-btn {
     display: inline-block;
-    background-color: var(--color-primary);
-    color: var(--color-white);
-    padding: 12px;
+    background: none;
+    color: var(--color-text-light);
+    box-shadow: none;
+    display: inline-flex;
+    font-size: 0.95rem;
+    min-width: 110px;
+    height: 50px;
+    border: none;
     border-radius: 12px;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
   }
 }
 

--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -22,26 +22,17 @@ class ChildrenController < ApplicationController
 
     @user = User.new(session[:user_params])
     @user.assign_attributes(user_children_params)
-    # @child = @user.children.build(child_params)
 
-    # トランザクションで両方を保存
-    ActiveRecord::Base.transaction do
-      @user.save!
-      # @child.save!
-
-      # ログイン処理
+    if @user.save
       auto_login(@user)
-      # session をクリア
       session.delete(:user_params)
       session[:current_child_id] = @user.children.first.id
 
       flash[:success] = "登録が完了しました"
       redirect_to new_child_recording_path(session[:current_child_id])
+    else
+      render :new, status: :unprocessable_entity
     end
-
-  rescue ActiveRecord::RecordInvalid => e
-    flash.now[:alert] = "登録に失敗しました: #{e.message}"
-    render :new, status: :unprocessable_entity
   end
 
   def edit

--- a/app/controllers/recordings_controller.rb
+++ b/app/controllers/recordings_controller.rb
@@ -23,9 +23,15 @@ class RecordingsController < ApplicationController
         recording_id: @recording.id
       }, status: :created
     else
+      error_message = if @recording.errors[:duration].present?
+        "録音が正しく保存されませんでした。もう一度録音してください。"
+      else
+        "保存に失敗しました。入力内容をご確認ください。"
+      end
+
       render json: {
         success: false,
-        errors: @recording.errors.full_messages
+        message: error_message
       }, status: :unprocessable_entity
     end
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,7 @@
 import "./src/recordings"
 import "./src/recording_show"
 import "./src/children"
+import "./src/password_toggle"
 import "@hotwired/turbo-rails"
 import "controllers"
 import { initDropdown } from "src/dropdown"

--- a/app/javascript/src/password_toggle.js
+++ b/app/javascript/src/password_toggle.js
@@ -1,0 +1,14 @@
+document.addEventListener("turbo:load", () => {
+  document.querySelectorAll(".password-toggle-button").forEach((button) => {
+    button.addEventListener("click", () => {
+      const field = button.closest(".password-field-wrap").querySelector(".password-field");
+      const icon = button.querySelector("i");
+
+      const isHidden = field.type === "password";
+      field.type = isHidden ? "text" : "password";
+
+      icon.classList.toggle("fa-eye", isHidden);
+      icon.classList.toggle("fa-eye-slash", !isHidden);
+    });
+  });
+});

--- a/app/javascript/src/recordings.js
+++ b/app/javascript/src/recordings.js
@@ -232,7 +232,7 @@ document.addEventListener('turbo:load', () => {
             window.location.href = `/children/${childId}/recordings/${data.recording_id}`;
           }, 800);
         } else {
-          showError('保存に失敗しました: ' + (data.errors || '不明なエラー'));
+          showError(data.message || '保存に失敗しました。もう一度お試しください。');
         }
       } catch (error) {
         console.error('保存エラー:', error);

--- a/app/views/children/new.html.erb
+++ b/app/views/children/new.html.erb
@@ -39,7 +39,7 @@
               <%= child_form.date_field :birthday, class: "form-control date-field" %>
 
               <% if child_form.object.errors[:birthday].any? %>
-                <div class= "errors-message">
+                <div class="errors-message">
                   <%= child_form.object.errors.full_messages_for(:birthday).join(", ") %>
                 </div>
               <% end %>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -10,12 +10,24 @@
 
       <div class="form-group">
         <%= f.label :password, "新しいパスワード", class: "form-label" %>
-        <%= f.password_field :password, class: "form-field" %>
+
+        <div class="password-field-wrap">
+          <%= f.password_field :password, class: "form-field password-field", placeholder: "半角英数字" %>
+          <button type="button" class="password-toggle-button" aria-label="パスワードを表示">
+            <i class="fa-regular fa-eye-slash"></i>
+          </button>
+        </div>
       </div>
 
       <div class="form-group">
         <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "form-label" %>
-        <%= f.password_field :password_confirmation, class: "form-field" %>
+
+        <div class="password-field-wrap">
+          <%= f.password_field :password_confirmation, class: "form-field password-field", placeholder: "半角英数字" %>
+          <button type="button" class="password-toggle-button" aria-label="パスワードを表示">
+            <i class="fa-regular fa-eye-slash"></i>
+          </button>
+        </div>
       </div>
 
       <div class="actions">

--- a/app/views/recordings/index.html.erb
+++ b/app/views/recordings/index.html.erb
@@ -30,7 +30,7 @@
     <% end %>
 
     <div class="back-home-area">
-      <%= link_to "ホームへ", new_child_recording_path(@child.id), class: "home-btn" %>
+      <%= link_to "ホームにもどる", new_child_recording_path(@child.id), class: "home-btn" %>
     </div>
   </div>
 </div>

--- a/app/views/recordings/on_this_day.html.erb
+++ b/app/views/recordings/on_this_day.html.erb
@@ -39,7 +39,7 @@
     <% end %>
 
     <div class="back-home-area">
-      <%= link_to "[ もどる ]", new_child_recording_path(@child.id), class: "home-btn" %>
+      <%= link_to "ホームにもどる", new_child_recording_path(@child.id), class: "home-btn" %>
     </div>
   </div>
 </div>

--- a/app/views/recordings/show.html.erb
+++ b/app/views/recordings/show.html.erb
@@ -73,7 +73,7 @@
 
     <!-- 戻る -->
     <div class="back-section">
-      <%= link_to "[ ことば一覧にもどる] ", child_recordings_path(@recording.child), class: "back-btn" %>
+      <%= link_to "ことば一覧にもどる", child_recordings_path(@recording.child), class: "back-btn" %>
     </div>
   </div>
 </div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -55,7 +55,7 @@
     </div>
 
     <div class="settings-actions">
-      <%= link_to "← もどる", new_child_recording_path(current_child), class: "setting-back-link" %>
+      <%= link_to "もどる", new_child_recording_path(current_child), class: "setting-back-link" %>
       <%= button_to "ログアウト", logout_path, method: :delete, class: "setting-logout-btn" %>
     </div>
   </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       user: ユーザー
       child: お子さま
+      recording: 記録
     attributes:
       user:
         name: お名前
@@ -10,8 +11,15 @@ ja:
         password: パスワード
         password_confirmation: パスワード（確認）
       child:
-        name: お子さまのお名前（1人目）
+        name: お子さまのお名前
         birthday: 生年月日
+      user/children:
+        name: お子さまのお名前
+        birthday: 生年月日
+      recording:
+        title: タイトル
+        comment: ひとこと
+        duration: 記録時間
     errors:
       messages:
         blank: "を入力してください"


### PR DESCRIPTION
## 概要
バリデーションエラー時のメッセージの表示形式が画面によって異なるため修正
パスワードリセット時の入力フィールドに「表示/非表示」のアイコンを設置

## 実装内容
- ja.yml に足りない日本語設定を追加し、バリデーションエラー時に正常に日本語で表示されるよう修正
- 録音保存時のバリデーションエラー時の、フラッシュメッセージの表示形式を変更
- 子ども登録画面でエラーが発生した際、入力フィールドの下にメッセージが表示されるよう修正
- パスワード再設定画面（edit）で、入力内容を表示/非表示をアイコンで切り替えられるよう`html`、`SCSS`、`JS`の内容を更新
