### PR TITLE
FormObjectを導入してユーザー登録処理を整理する

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -20,17 +20,20 @@ class ChildrenController < ApplicationController
       return
     end
 
-    @user = User.new(session[:user_params])
-    @user.assign_attributes(user_children_params)
+    @form = UserRegistrationForm.new(
+      user_params: session[:user_params],
+      children_params: user_children_params[:children_attributes]
+    )
 
-    if @user.save
-      auto_login(@user)
+    if @form.save
+      auto_login(@form.user)
       session.delete(:user_params)
-      session[:current_child_id] = @user.children.first.id
+      session[:current_child_id] = @form.user.children.first.id
 
       flash[:success] = "登録が完了しました"
       redirect_to new_child_recording_path(session[:current_child_id])
     else
+      @user = @form.user
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/forms/user_registration_form.rb
+++ b/app/forms/user_registration_form.rb
@@ -1,0 +1,30 @@
+class UserRegistrationForm
+  include ActiveModel::Model
+
+  attr_reader :user
+
+  def initialize(user_params:, children_params:)
+    @user_params = user_params
+    @children_params = children_params
+    @user = User.new(@user_params)
+    build_children
+  end
+
+  def save
+    return false unless user.valid?
+
+    user.save
+  end
+
+  private
+
+  attr_reader :user_params, :children_params
+
+  def build_children
+    return if children_params.blank?
+
+    children_params.each_value do |child_params|
+      user.children.build(child_params)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
FormObjectを導入してユーザー登録処理を整理する

## 対象ISSUE
close #190 

## 実装内容
- `UserRegistractionForm` などの FormObject を作成する
- `session` に一時保存しているユーザー情報と子ども情報を FormObject で扱う
- User と Child をまとめて保存する処理を FormObject へ移す
- バリデーションエラーを既存の画面表示に合わせる
- ChildrenController / UsersController の登録処理を整理する
- 既存の登録フローが壊れていないか確認する
- 必要に応じて既存テストを修正する

## 動作確認
1. 新規登録画面を開ける
2. ユーザー情報入力 → 確認画面へ進める
3. 確認画面から戻れる
4. 子ども情報入力 → 登録完了できる
5. 登録後に自動ログインされる
6. 録音画面へ遷移する
7. 子ども情報未入力時にエラーが入力欄下に出る
8. 同じメールアドレスで登録時にエラーが出る 
