### PR TITLE
録音保存時にローディング表示を追加

### DIFF
--- a/app/assets/stylesheets/recordings.scss
+++ b/app/assets/stylesheets/recordings.scss
@@ -766,6 +766,8 @@
   }
 
   .back-section {
+    display: flex;
+    flex-direction: column;
     text-align: center;
     margin-top: var(--spacing-xl);
   }

--- a/app/javascript/src/recordings.js
+++ b/app/javascript/src/recordings.js
@@ -60,6 +60,8 @@ document.addEventListener('turbo:load', () => {
 
       if (!confirmed) return;
 
+      clearMessages();
+
       const audioPlayer = document.getElementById('audio-player');
       const seekBar = document.getElementById('seek-bar');
       const currentTime = document.getElementById('current-time');
@@ -111,6 +113,7 @@ document.addEventListener('turbo:load', () => {
   }
 
   startButton.addEventListener('click', async () => {
+    clearMessages();
     showScreen('recording-screen');
 
     try {
@@ -193,11 +196,26 @@ document.addEventListener('turbo:load', () => {
     setupAudioControls();
   }
 
+  function clearMessages() {
+    const errorMessages = document.getElementById('error-messages');
+    const successMessages = document.getElementById('success-messages');
+
+    if (errorMessages) errorMessages.innerHTML = '';
+    if (successMessages) successMessages.innerHTML = '';
+  }
+
   function setupFormSubmit() {
     if (!saveForm) return;
 
+    const saveButton = document.getElementById('save-button');
+
     saveForm.addEventListener('submit', async (e) => {
       e.preventDefault();
+
+      clearMessages();
+
+      // 二重送信防止
+      if (saveButton && saveButton.disabled) return;
 
       if (!recordedAudioBlob) {
         showError('保存する音声がありません。先に録音してください。');
@@ -210,6 +228,12 @@ document.addEventListener('turbo:load', () => {
         recordedAudioBlob,
         `recording.${selectedFileExtension}`
       );
+
+      // 保存中の表示
+      if (saveButton) {
+        saveButton.disabled = true;
+        saveButton.value = '保存中…';
+      }
 
       try {
         const token = document.querySelector('[name="csrf-token"]').content;
@@ -226,17 +250,32 @@ document.addEventListener('turbo:load', () => {
         const data = await response.json();
 
         if (response.ok) {
+          clearMessages();
           showSuccess('録音を保存しました！');
+
+          if (saveButton) {
+            saveButton.value = '保存しました';
+          }
 
           setTimeout(() => {
             window.location.href = `/children/${childId}/recordings/${data.recording_id}`;
           }, 800);
         } else {
           showError(data.message || '保存に失敗しました。もう一度お試しください。');
+
+          if (saveButton) {
+            saveButton.disabled = false;
+            saveButton.value = '保存';
+          }
         }
       } catch (error) {
         console.error('保存エラー:', error);
         showError('保存中にエラーが発生しました。');
+
+        if (saveButton) {
+          saveButton.disabled = false;
+          saveButton.value = '保存';
+        }
       }
     });
   }

--- a/app/views/recordings/show.html.erb
+++ b/app/views/recordings/show.html.erb
@@ -73,6 +73,7 @@
 
     <!-- 戻る -->
     <div class="back-section">
+      <%= link_to "[ ことばをのこす ]", new_child_recording_path(@child.id), class: "home-btn" %>
       <%= link_to "← ことば一覧にもどる", child_recordings_path(@recording.child), class: "back-btn" %>
     </div>
   </div>


### PR DESCRIPTION
## 概要
録音保存など時間がかかる処理中に、ユーザーが現在の状態を理解できるようにする。

## 対象ISSUE
close #182 

## 実装内容
- 録音保存ボタン押下時にボタンを`desabled` 化
- ボタン文言を「保存中…」へ変更
- 二重送信防止
- 保存成功時は詳細画面へ遷移
- 保存失費味はボタン状態を元に戻す
- 通信失敗時も再操作可能にする

## 完了条件
- [ ] 保存中に再度ボタンを押せない
- [ ] 保存処理中であることが分かる
- [ ] 保存成功時に詳細画面へ遷移できる
- [ ] 保存失敗時に再度保存できる