### PR TITLE
詳細画面にお気に入り登録ボタンを追加/非同期更新にて登録・解除を行えるように⏬

### DIFF
--- a/app/assets/stylesheets/recordings.scss
+++ b/app/assets/stylesheets/recordings.scss
@@ -509,7 +509,21 @@
   }
 
   .detail-section {
-    margin-bottom: var(--spacing-lg);
+    margin-bottom: 0.25rem;
+  }
+
+  .title-section {
+    margin-bottom: 0;
+  }
+
+  .favorite-area {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 4px;
+  }
+
+  .favorite-area form {
+    margin: 0;
   }
 
   .detail-label {
@@ -530,6 +544,7 @@
     border: 1px solid var(--color-border);
     border-radius: 12px;
     padding: var(--spacing-md);
+    margin: 0;
     background-color: var(--color-white);
     min-height: 30px;
     letter-spacing: 0.03rem;
@@ -799,6 +814,31 @@
       font-size: 1rem;
     }
   }
+}
+
+/* ========================================
+  　 お気に入りボタン
+======================================== */
+.favorite-button {
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: #8f8f8f;
+  font-size: 1.3rem;
+  font-family: var(--font-main);
+  cursor: pointer;
+}
+
+.favorite-button i {
+  margin-right: 4px;
+}
+
+.favorite-button:hover {
+  opacity: 0.8;
+}
+
+.favorite-button.favorited {
+  color: #d98b8b;
 }
 
 /* ========================================

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,33 @@
+class FavoritesController < ApplicationController
+  before_action :set_child
+  before_action :set_recording
+
+  def create
+    current_user.favorites.find_or_create_by!(recording: @recording)
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: child_recording_path(@child, @recording) }
+    end
+  end
+
+  def destroy
+    favorite = current_user.favorites.find_by(recording: @recording)
+    favorite&.destroy
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: child_recording_path(@child, @recording) }
+    end
+  end
+
+  private
+
+  def set_child
+    @child = current_user.children.find(params[:child_id])
+  end
+
+  def set_recording
+    @recording = @child.recordings.find(params[:recording_id])
+  end
+end

--- a/app/decorators/favorite_decorator.rb
+++ b/app/decorators/favorite_decorator.rb
@@ -1,0 +1,13 @@
+class FavoriteDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/decorators/favorite_decorator.rb
+++ b/app/decorators/favorite_decorator.rb
@@ -9,5 +9,4 @@ class FavoriteDecorator < Draper::Decorator
   #       object.created_at.strftime("%a %m/%d/%y")
   #     end
   #   end
-
 end

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -1,0 +1,2 @@
+module FavoritesHelper
+end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,6 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :recording
+
+  validates :user_id, uniqueness: { scope: :recording_id }
+end

--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -5,6 +5,8 @@ class Recording < ApplicationRecord
   has_one_attached :audio, dependent: :purge_later
   before_validation :set_recorded_at, on: :create
 
+  has_many :favorites, dependent: :destroy
+
   validates :title, presence: true
   validates :recorded_at, presence: true
   validates :duration,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
 
   has_many :children, dependent: :destroy
+  has_many :favorites, dependent: :destroy
   accepts_nested_attributes_for :children, allow_destroy: true
 
   validates :name, presence: true

--- a/app/views/favorites/_favorite_button.html.erb
+++ b/app/views/favorites/_favorite_button.html.erb
@@ -1,0 +1,17 @@
+<%= turbo_frame_tag "favorite_button_#{recording.id}" do %>
+  <% favorite = current_user.favorites.find_by(recording_id: recording.id) %>
+
+  <% if favorite.present? %>
+    <%= button_to child_recording_favorite_path(child, recording),
+          method: :delete,
+          class: "favorite-button favorited" do %>
+      <i class="fa-solid fa-heart"></i>
+    <% end %>
+  <% else %>
+    <%= button_to child_recording_favorite_path(child, recording),
+          method: :post,
+          class: "favorite-button" do %>
+      <i class="fa-regular fa-heart"></i>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/favorites/create.turbo_stream.erb
+++ b/app/views/favorites/create.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.replace "favorite_button_#{@recording.id}" do %>
+  <%= render "favorites/favorite_button",
+        recording: @recording,
+        child: @child %>
+<% end %>

--- a/app/views/favorites/destroy.turbo_stream.erb
+++ b/app/views/favorites/destroy.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.replace "favorite_button_#{@recording.id}" do %>
+  <%= render "favorites/favorite_button",
+        recording: @recording,
+        child: @child %>
+<% end %>

--- a/app/views/recordings/show.html.erb
+++ b/app/views/recordings/show.html.erb
@@ -5,9 +5,15 @@
     <p class="child-name"><%= @recording.child.name %></p>
 
     <!-- タイトル -->
-    <div class="detail-section">
+    <div class="detail-section title-section">
       <p class="detail-label">タイトル</p>
       <p class="detail-value detail-title"><%= @recording.title %></p>
+    </div>
+
+    <div class="favorite-area">
+      <%= render "favorites/favorite_button",
+            recording: @recording,
+            child: @child %>
     </div>
 
     <!-- ひとこと -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "favorites/create"
+  get "favorites/destroy"
   get "settings/show"
   root "top#index"
 
@@ -31,6 +33,8 @@ Rails.application.routes.draw do
         get :preview
         get :on_this_day
       end
+
+      resource :favorite, only: %i[create destroy]
     end
   end
 

--- a/db/migrate/20260516105201_create_favorites.rb
+++ b/db/migrate/20260516105201_create_favorites.rb
@@ -1,0 +1,12 @@
+class CreateFavorites < ActiveRecord::Migration[8.0]
+  def change
+    create_table :favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :recording, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :favorites, [:user_id, :recording_id], unique: true
+  end
+end

--- a/db/migrate/20260516105201_create_favorites.rb
+++ b/db/migrate/20260516105201_create_favorites.rb
@@ -7,6 +7,6 @@ class CreateFavorites < ActiveRecord::Migration[8.0]
       t.timestamps
     end
 
-    add_index :favorites, [:user_id, :recording_id], unique: true
+    add_index :favorites, [ :user_id, :recording_id ], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_09_063029) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_16_105201) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -51,6 +51,16 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_09_063029) do
     t.index ["user_id"], name: "index_children_on_user_id"
   end
 
+  create_table "favorites", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "recording_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recording_id"], name: "index_favorites_on_recording_id"
+    t.index ["user_id", "recording_id"], name: "index_favorites_on_user_id_and_recording_id", unique: true
+    t.index ["user_id"], name: "index_favorites_on_user_id"
+  end
+
   create_table "recordings", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "child_id", null: false
@@ -83,6 +93,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_09_063029) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "children", "users"
+  add_foreign_key "favorites", "recordings"
+  add_foreign_key "favorites", "users"
   add_foreign_key "recordings", "children"
   add_foreign_key "recordings", "users"
 end

--- a/spec/decorators/favorite_decorator_spec.rb
+++ b/spec/decorators/favorite_decorator_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe FavoriteDecorator do
+end

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :favorite do
+    user { nil }
+    recording { nil }
+  end
+end

--- a/spec/helpers/favorites_helper_spec.rb
+++ b/spec/helpers/favorites_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the FavoritesHelper. For example:
+#
+# describe FavoritesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe FavoritesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Favorite, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "Favorites", type: :request do
+  describe "GET /create" do
+    it "returns http success" do
+      get "/favorites/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/favorites/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -14,5 +14,4 @@ RSpec.describe "Favorites", type: :request do
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/spec/views/favorites/create.html.tailwindcss_spec.rb
+++ b/spec/views/favorites/create.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "favorites/create.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/favorites/destroy.html.tailwindcss_spec.rb
+++ b/spec/views/favorites/destroy.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "favorites/destroy.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
録音詳細画面および一覧画面から、非同期更新で記録をお気に入り登録・解除できるようにする。

## 対象ISSUE
close #173 

## 実装内容

### バックエンド
- Favorite モデル作成
- User / Recording / Favorite の関連付け
- バリデーション追加
  - `user_id + recording_id` の一意制的
- favorite controller 作成
- create / destroy 実装
- 認可制御

### フロントエンド
- 録音詳細画面にお気に入りボタン追加
- 一覧画面にお気に入りボタン追加
- お気に入り済み状態の見た目変更
- お気に入り解除対応
- Turboを利用したお気に入り登録 / 解除の非同期更新

## 確認事項
- [ ] 詳細画面からお気に入り登録・解除ができる
- [ ] 一覧画面からお気に入り登録・解除ができる
- [ ] 二重登録できない
- [ ] 他ユーザーの記録を操作できない
- [ ] UIでお気に入り状態が分かる
- [ ] ページリロードなしでお気に入り状態が切り替わる