### PR TITLE
お気に入り一覧画面の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,3 +10,4 @@
 @use 'users';
 @use 'user_sessions';
 @use 'static_pages';
+@use 'favorites';

--- a/app/assets/stylesheets/favorites.scss
+++ b/app/assets/stylesheets/favorites.scss
@@ -1,0 +1,185 @@
+/* ========================================
+  　 お気に入りボタン
+======================================== */
+.favorite-button {
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: #8f8f8f;
+  font-size: 1.3rem;
+  font-family: var(--font-main);
+  cursor: pointer;
+}
+
+.favorite-button i {
+  margin-right: 4px;
+}
+
+.favorite-button:hover {
+  opacity: 0.8;
+}
+
+.favorite-button.favorited {
+  color: #d98b8b;
+}
+
+/* =================================
+    favorites#index - お気に入り一覧
+==================================*/
+
+#favorite-recordings-index-page {
+    background-color: var(--color-primary-light);
+  min-height: 100vh;
+  padding: var(--spacing-lg) var(--spacing-md);
+
+  .favorite-recordings-index-card {
+    max-width: 420px;
+    margin: 0 auto;
+    background-color: var(--color-white);
+    border-radius: 20px;
+    padding: var(--spacing-lg);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  }
+
+  .page-title {
+    font-size: 1.4rem;
+    text-align: center;
+    margin-bottom: var(--spacing-lg);
+    color: var(--color-text);
+  }
+
+  .recordings-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
+  }
+
+  .recording-item-wrapper {
+    position: relative;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .recording-item {
+    display: flex;
+    justify-content: space-between;
+    padding: 14px 36px 14px 0;
+  }
+
+  .recording-item-right {
+    display: grid;
+    grid-template-columns: auto auto;
+    column-gap: 8px;
+    row-gap: 2px;
+    align-items: center;
+  }
+
+  .recording-title {
+    font-size: 1.1rem;
+    font-weight: bold;
+    margin-bottom: 4px;
+    line-height: 1.4;
+  }
+
+  .recording-date {
+    grid-column: 1 / 3;
+  }
+
+  .recording-age {
+    grid-column: 1;
+  }
+
+  .recording-duration {
+    font-size: 0.95rem;
+    color: var(--color-text-light);
+    line-height: 1.3;
+  }
+
+  .favorite-area {
+    position: absolute;
+    right: 6px;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .favorite-area form {
+    margin: 0;
+  }
+
+  .favorite-button {
+    line-height: 1;
+    font-size: 1.2rem;
+  }
+
+  .pagination-area {
+    margin-top: var(--spacing-xl);
+    display: flex;
+    justify-content: center;
+  }
+
+  .pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-sm);
+    flex-wrap: wrap;
+  }
+
+  .pagination > span,
+  .pagination  > a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 40px;
+    height: 40px;
+    padding: 0 var(--spacing-sm);
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+    background-color: var(--color-white);
+    color: var(--color-text);
+    font-size: 0.95rem;
+    margin-top: var(--spacing-md);
+    text-decoration: none;
+  }
+
+  .pagination .current {
+    background-color: var(--color-primary);
+    color: var(--color-white);
+    border-color: var(--color-primary);
+  }
+
+  .pagination .disabled {
+    color: var(--color-text-light);
+    background-color: #f7f7f7;
+  }
+
+  .pagination > span > a:hover {
+    opacity: 0.8;
+  }
+
+  .empty-message {
+    text-align: center;
+    color: var(--color-text-light);
+    padding: var(--spacing-xl) 0;
+  }
+
+  .back-home-area {
+    text-align: center;
+    margin-top: var(--spacing-xl);
+  }
+
+  .home-btn {
+    display: inline-block;
+    background: none;
+    color: var(--color-text-light);
+    box-shadow: none;
+    display: inline-flex;
+    font-size: 0.95rem;
+    min-width: 110px;
+    height: 50px;
+    border: none;
+    border-radius: 12px;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+  }
+}

--- a/app/assets/stylesheets/recordings.scss
+++ b/app/assets/stylesheets/recordings.scss
@@ -817,31 +817,6 @@
 }
 
 /* ========================================
-  　 お気に入りボタン
-======================================== */
-.favorite-button {
-  border: none;
-  background: transparent;
-  padding: 0;
-  color: #8f8f8f;
-  font-size: 1.3rem;
-  font-family: var(--font-main);
-  cursor: pointer;
-}
-
-.favorite-button i {
-  margin-right: 4px;
-}
-
-.favorite-button:hover {
-  opacity: 0.8;
-}
-
-.favorite-button.favorited {
-  color: #d98b8b;
-}
-
-/* ========================================
    recordings#index - 録音一覧画面専用
 ======================================== */
 #recordings-index-page {

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,6 +1,6 @@
 class FavoritesController < ApplicationController
-  before_action :set_child
-  before_action :set_recording
+  before_action :set_child, only: %i[create destroy]
+  before_action :set_recording, only: %i[create destroy]
 
   def create
     current_user.favorites.find_or_create_by!(recording: @recording)
@@ -19,6 +19,17 @@ class FavoritesController < ApplicationController
       format.turbo_stream
       format.html { redirect_back fallback_location: child_recording_path(@child, @recording) }
     end
+  end
+
+  def index
+    @child = current_user.children.find(params[:child_id]).decorate
+    @favorites = current_user.favorites
+                             .joins(:recording)
+                             .where(recordings: { child_id: @child.id })
+                             .includes(recording: :child)
+                             .order("recordings.recorded_at DESC")
+                             .page(params[:page])
+                             .per(5)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
 
   has_many :children, dependent: :destroy
   has_many :favorites, dependent: :destroy
+  has_many :recordings, through: :favorites, source: :recording
   accepts_nested_attributes_for :children, allow_destroy: true
 
   validates :name, presence: true

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,0 +1,47 @@
+<div id="favorite-recordings-index-page">
+  <div class="favorite-recordings-index-card">
+
+    <h1 class="page-title">大切なことば</h1>
+
+    <% if @favorites.any? %>
+      <div class="recordings-list">
+        <% @favorites.each do |favorite| %>
+          <% recording = favorite.recording %>
+
+          <div class="recording-item-wrapper">
+
+            <%= link_to child_recording_path(@child, recording), class: "recording-item" do %>
+              <div class="recording-item-left">
+                <p class="recording-title"><%= recording.title %></p>
+                <p class="recording-duration">
+                  <%= format_duration(recording.duration) %>
+                </p>
+              </div>
+
+              <div class="recording-item-right">
+                <p class="recording-date"><%= recording.recorded_at.strftime("%Y/%m/%d") %></p>
+                <p class="recording-age"><%= @child.age_at(recording.recorded_at) %></p>
+              </div>
+            <% end %>
+
+            <div class="favorite-area">
+              <%= render "favorites/favorite_button",
+                    recording: recording,
+                    child: @child %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="pagination-area">
+        <%= paginate @favorites %>
+      </div>
+    <% else %>
+      <p class="empty-message">まだ大切なことばはありません</p>
+    <% end %>
+
+    <div class="back-home-area">
+      <%= link_to "← ホームにもどる", new_child_recording_path(@child), class: "home-btn" %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header_main.html.erb
+++ b/app/views/shared/_header_main.html.erb
@@ -69,6 +69,10 @@
             class: "side-menu-link #{'active' if current_page?(child_recordings_path(current_child))}" %>
         </li>
         <li>
+          <%= link_to "大切なことば", child_favorites_path(current_child),
+            class: "side-menu-link #{'active' if current_page?(child_favorites_path(current_child))}" %>
+        </li>
+        <li>
           <%= link_to "一年前の今日", on_this_day_child_recordings_path(current_child),
             class: "side-menu-link #{'active' if current_page?(on_this_day_child_recordings_path(current_child))}" %>
         </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
       post :switch
     end
 
+    resources :favorites, only: %i[index]
+
     # 録音機能（お子様に紐付く）
     resources :recordings, only: %i[index new create show edit update destroy] do
       collection do


### PR DESCRIPTION
## 概要
お気に入り登録した記録を一覧表示し、振り返りやすくする。

## 対象ISSUE
close #183 

## 実装内容

### バックエンド
- favorites #index 作成
- `current_user` のお気に入り取得

### フロントエンド
- お気に入り一覧画面の作成
- 一覧から詳細画面へ遷移
- 一覧上でお気に入り解除できる
- 空状態UI作成
- ハンバーガーメニューに導線追加

## 完了条件
- [ ] お気に入り登録済みの記録だけが表示される
- [ ] 一覧から詳細へ遷移する
- [ ] お気に入り0件時に自然なUIにする
- [ ] スマホ表示で崩れない

## 備考
この後にISSUE追加（#）
詳細画面への導線が複数あるため、詳細画面から戻る時のリンクを該当のページによって出し分ける。