### PR TITLE
詳細画からの戻るリンクを遷移元ごとに動的に切り替える

### DIFF
--- a/app/javascript/src/recordings.js
+++ b/app/javascript/src/recordings.js
@@ -258,7 +258,7 @@ document.addEventListener('turbo:load', () => {
           }
 
           setTimeout(() => {
-            window.location.href = `/children/${childId}/recordings/${data.recording_id}`;
+            window.location.href = `/children/${childId}/recordings/${data.recording_id}?from=recording`;
           }, 800);
         } else {
           showError(data.message || '保存に失敗しました。もう一度お試しください。');

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -10,7 +10,7 @@
 
           <div class="recording-item-wrapper">
 
-            <%= link_to child_recording_path(@child, recording), class: "recording-item" do %>
+            <%= link_to child_recording_path(@child, recording, from: "favorites"), class: "recording-item" do %>
               <div class="recording-item-left">
                 <p class="recording-title"><%= recording.title %></p>
                 <p class="recording-duration">
@@ -41,7 +41,7 @@
     <% end %>
 
     <div class="back-home-area">
-      <%= link_to "← ホームにもどる", new_child_recording_path(@child), class: "home-btn" %>
+      <%= link_to "[ことばをのこす]", new_child_recording_path(@child), class: "home-btn" %>
     </div>
   </div>
 </div>

--- a/app/views/recordings/index.html.erb
+++ b/app/views/recordings/index.html.erb
@@ -6,7 +6,7 @@
     <% if @recordings.any? %>
       <div class="recordings-list">
         <% @recordings.each do |recording| %>
-          <%= link_to child_recording_path(@child, recording), class: "recording-item" do %>
+          <%= link_to child_recording_path(@child, recording, from: "recordings"), class: "recording-item" do %>
             <div class="recording-item-left">
               <p class="recording-title"><%= recording.title %></p>
               <p class="recording-duration">

--- a/app/views/recordings/on_this_day.html.erb
+++ b/app/views/recordings/on_this_day.html.erb
@@ -13,7 +13,7 @@
     <% if @recordings.any? %>
       <div class="recordings-list">
         <% @recordings.each do |recording| %>
-          <%= link_to child_recording_path(@child, recording), class: "recording-item" do %>
+          <%= link_to child_recording_path(@child, recording, from: "on_this_day"), class: "recording-item" do %>
             <div class="recording-item-left">
               <p class="recording-title"><%= recording.title %></p>
               <p class="recording-duration">
@@ -39,7 +39,7 @@
     <% end %>
 
     <div class="back-home-area">
-      <%= link_to "← ホームにもどる", new_child_recording_path(@child.id), class: "home-btn" %>
+      <%= link_to "[ ことばをのこす]", new_child_recording_path(@child), class: "home-btn" %>
     </div>
   </div>
 </div>

--- a/app/views/recordings/show.html.erb
+++ b/app/views/recordings/show.html.erb
@@ -77,10 +77,26 @@
       <% end %>
     </audio>
 
-    <!-- 戻る -->
     <div class="back-section">
-      <%= link_to "[ ことばをのこす ]", new_child_recording_path(@child.id), class: "home-btn" %>
-      <%= link_to "← ことば一覧にもどる", child_recordings_path(@recording.child), class: "back-btn" %>
+      <% case params[:from] %>
+      <% when "recording" %>
+        <%= link_to "← ホームにもどる", new_child_recording_path(@child.id), class: "home-btn" %>
+
+      <% when "favorites" %>
+        <%= link_to "← 大切なことばにもどる", child_favorites_path(@child), class: "back-btn" %>
+
+        <%= link_to "[ことばをのこす]", new_child_recording_path(@child), class: "home-btn" %>
+
+      <% when "on_this_day" %>
+        <%= link_to "← 一年前の今日にもどる", on_this_day_child_recordings_path(@child), class: "back-btn" %>
+
+        <%= link_to "[ことばをのこす]", new_child_recording_path(@child), class: "home-btn" %>
+
+      <% else %>
+        <%= link_to "← ことば一覧にもどる", child_recordings_path(@child), class: "back-btn" %>
+
+        <%= link_to "[ことばをのこす]", new_child_recording_path(@child), class: "home-btn" %>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 概要
詳細画面への入り口が複数あるため、遷移元に合わせて戻る導線を切り替える
### 詳細画面への複数導線
- 録音画面→詳細画面→戻る（ホームへ）
- 一覧画面→詳細画面→戻る（ことばをのこす・一覧へもどる）
- お気に入り一覧画面→詳細画面→戻る（ことばをのこす・大切なことば一覧画面へもどる）
- 一年前の今日→詳細画面→戻る（ことばをのこす・一年前の今日へもどる）

## 対象ISSUE
#196 

## 実装内容
- 詳細画面へ遷移するリンクに `from` を付ける
- 詳細画面で戻るリンクを切り替える
- 動作確認