### PR TITLE
お気に入りのテストを追加・実行

### DIFF
--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :favorite do
-    user { nil }
-    recording { nil }
+    association :user
+    association :recording
   end
 end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,5 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Favorite, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "バリデーション" do
+    it "user と recording があれば有効" do
+      favorite = build(:favorite)
+
+      expect(favorite).to be_valid
+    end
+
+    it "同じユーザーが同じ録音を重複してお気に入りできない" do
+      user = create(:user)
+      recording = create(:recording)
+
+      create(:favorite, user: user, recording: recording)
+      favorite = build(:favorite, user: user, recording: recording)
+
+      expect(favorite).to be_invalid
+    end
+  end
 end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -1,17 +1,67 @@
 require 'rails_helper'
 
 RSpec.describe "Favorites", type: :request do
-  describe "GET /create" do
-    it "returns http success" do
-      get "/favorites/create"
-      expect(response).to have_http_status(:success)
+  def login_as(user)
+    post login_path, params: {
+      email: user.email,
+      password: "password"
+    }
+  end
+  describe "POST /children/:child_id/recordings/:recording_id/favorite" do
+    it "お気に入り登録できる" do
+      user = create(:user, password: "password", password_confirmation: "password")
+      child = create(:child, user: user)
+      recording = create(:recording, user: user, child: child)
+
+      login_as(user)
+
+      expect {
+        post child_recording_favorite_path(child, recording)
+      }.to change(Favorite, :count).by(1)
+
+      expect(response).to have_http_status(:redirect)
+    end
+
+    it "未ログイン時はログイン画面へリダイレクトされる" do
+      user = create(:user)
+      child = create(:child, user: user)
+      recording = create(:recording, user: user, child: child)
+
+      post child_recording_favorite_path(child, recording)
+
+      expect(response).to redirect_to(login_path)
+    end
+
+    it "他ユーザーの録音はお気に入りできない" do
+      user = create(:user, password: "password", password_confirmation: "password")
+      create(:child, user: user)
+
+      other_user = create(:user)
+      other_child = create(:child, user: other_user)
+      other_recording = create(:recording, user: other_user, child: other_child)
+
+      login_as(user)
+
+      expect {
+        post child_recording_favorite_path(other_child, other_recording)
+      }.not_to change(Favorite, :count)
     end
   end
 
-  describe "GET /destroy" do
-    it "returns http success" do
-      get "/favorites/destroy"
-      expect(response).to have_http_status(:success)
+  describe "DELETE /children/:child_id/recordings/:recording_id/favorite" do
+    it "お気に入り解除できる" do
+      user = create(:user)
+      child = create(:child, user: user)
+      recording = create(:recording, user: user, child: child)
+      create(:favorite, user: user, recording: recording)
+
+      login_as(user)
+
+      expect {
+        delete child_recording_favorite_path(child, recording)
+    }.to change(Favorite, :count).by(-1)
+
+      expect(response).to have_http_status(:redirect)
     end
   end
 end


### PR DESCRIPTION
## 概要
本リリースで追加した「お気に入り機能」に対するテストを追加し、既存機能を含めた品質を維持する。

## 対象ISSUE
close #174 

## 実装内容
- Favorite モデルspec 追加
- `favorite_request_spec` 追加
- 必要に応じてシステムスペック追加
- FactoryBot 追加調整
- CIでテスト実行確認

## 完了条件
- [ ] Favorite モデルの正常系・異常系をテストできる
- [ ] お気に入り登録 / 解除をテストできる
- [ ] 未ログイン時の制御を確認できる
- [ ] `bundle exec rspec` が成功する