### PR TITLE
トップ画面と初回録音画面に使い方ガイドを追加

### DIFF
--- a/app/assets/stylesheets/recordings.scss
+++ b/app/assets/stylesheets/recordings.scss
@@ -93,6 +93,19 @@
     color: var(--color-text);
   }
 
+  .record-guide {
+  margin-top: 1.4rem;
+  font-size: 0.95rem;
+  color: var(--color--text-light);
+  line-height: 1.8;
+  text-align: center;
+  }
+
+  .record-guide i {
+    color: #7FB77E;
+    margin-bottom: 0.5rem;
+  }
+
   /* 最近の録音3件 */
   .recent-recordings-section {
     width: 100%;

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -111,6 +111,51 @@
   margin: 0.3rem 0;
 }
 
+.usage-section {
+  margin-top: 110px;
+  text-align: center;
+}
+
+.usage-section h2 {
+  font-size: 1.35rem;
+  font-weight: 500;
+  margin-bottom: 24px;
+}
+
+.usage-cards {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+}
+
+.usage-card {
+  flex: 1;
+  background: #fffef9;
+  border-radius: 20px;
+  padding: 20px 12px;
+  text-align: center;
+}
+
+.usage-card h3 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: var(--color-text);
+}
+
+.usage-card i {
+  font-size: 1.5rem;
+  color: #7FB77E;
+  margin-bottom: 10px;
+}
+
+.usage-card p {
+  font-size: 0.78rem;
+  line-height: 1.7;
+  color: var(--color-text-light);
+  margin: 0;
+}
+
 /* ========================================
    レスポンシブ対応
 ======================================== */
@@ -142,6 +187,39 @@
     font-size: 0.9rem;
     line-height: 2;
     max-width: 300px;
+  }
+
+  .usage-section {
+    margin-top: 80px;
+  }
+
+  .usage-section h2 {
+    font-size: 1.25rem;
+    margin-bottom: 20px;
+  }
+
+  .usage-cards {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .usage-card {
+    padding: 18px 16px;
+  }
+
+  .usage-card i {
+    font-size: 1.3rem;
+    margin-bottom: 8px;
+  }
+
+  .usage-card h3 {
+    font-size: 0.95rem;
+    margin-bottom: 6px;
+  }
+
+  .usage-card p {
+    font-size: 0.8rem;
+    line-height: 1.6;
   }
 }
 

--- a/app/views/recordings/new.html.erb
+++ b/app/views/recordings/new.html.erb
@@ -18,6 +18,17 @@
       </button>
 
       <p class="record-start-label">ことばをのこす</p>
+
+      <% unless @child.recordings.exists? %>
+        <div class="record-guide">
+          <i class="fa-regular fa-lightbulb"></i>
+
+          <p>
+            今しか聞けないことばを、<br>
+            残してみませんか？
+          </p>
+        </div>
+      <% end %>
     </div>
 
     <div class="recent-recordings-section">

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -2,10 +2,12 @@
   <div class= "container mt-5">
     <div class= "row">
       <div class= "col-md-10 col-lg-8 mx-auto">
-        <h2 class="top-title text-center">この言葉、忘れたくない。</h2>
-      <div class="mb-5">
 
-        <div class="button-group">
+        <h2 class="top-title text-center">
+          この言葉、忘れたくない。
+        </h2>
+
+        <div class="button-group mb-5">
           <%= link_to "新規登録", new_user_path, class: "btn-primary-main" %>
           <%= link_to "ログイン", login_path, class: "btn-secondary-main" %>
         </div>
@@ -16,6 +18,42 @@
           今しか残せない瞬間を<br>
           未来の宝物に。
         </div>
+
+        <section class="usage-section">
+          <h2>ことのはの使い方</h2>
+
+          <div class="usage-cards">
+
+            <div class="usage-card">
+              <i class="fa-solid fa-microphone"></i>
+              <h3>ことばを残す</h3>
+              <p>
+                今しか聞けないことばを<br>
+                ワンタップで記録
+              </p>
+            </div>
+
+            <div class="usage-card">
+              <i class="fa-solid fa-headphones"></i>
+              <h3>ことばを振り返る</h3>
+              <p>
+                成長と一緒に<br>
+                あの日の声をもう一度
+              </p>
+            </div>
+
+            <div class="usage-card">
+              <i class="fa-regular fa-heart"></i>
+              <h3>ひとことを添える</h3>
+              <p>
+                その時の気持ちも<br>
+                一緒に残せる
+              </p>
+            </div>
+
+          </div>
+        </section>
+
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要
初めて訪れたユーザーが、サービスの使い方を理解できるようにする。

## 対象ISSUE
close #179 

## 実装内容
- トップページにザービス利用イメージを追加
- 録音０件の場合のみ、録音画面に簡単な使い方を表示

## 完了条件
- [ ] 未ログインユーザーがサービス内容を理解できる
- [ ] ログイン後、何をすれば良いか分かる
- [ ] 画面の雰囲気を壊さない文言になっている

## 備考
文章は短く。
「録音」より「ことばを残す」など、世界観に合わせる。
ユーザーが「何をするアプリか」「どの用に使うのか」を数秒で理解できる状態を目指す。