### PR TITLE
レスポンシブ表示の最終調整

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -147,6 +147,13 @@ body {
   flex-direction: column;
 }
 
+/* iPhone Safari の入力欄フォーカス時の自動ズーム防止 */
+input,
+textarea,
+select {
+  font-size: 16px !important;
+}
+
 /* ========================================
    共通レイアウト
 ======================================== */

--- a/app/assets/stylesheets/password_reset.scss
+++ b/app/assets/stylesheets/password_reset.scss
@@ -1,109 +1,3 @@
-#password-reset-page {
-  background-color: var(--color-primary-light);
-  min-height: 100vh;
-  padding: var(--spacing-lg) var(--spacing-md);
-
-  .password-reset-card {
-    max-width: 420px;
-    margin: 0 auto;
-    background-color: var(--color-white);
-    border-radius: 20px;
-    padding: 32px 24px;
-    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
-  }
-
-  .password-reset-title {
-    text-align: center;
-    color: var(--color-text);
-    margin: var(--spacing-md) auto;
-    font-size: 1.4rem;
-  }
-
-  .description {
-    width: fit-content;
-    text-align: center;
-    font-size: 0.9rem;
-    color: var(--color-text-light);
-    margin: 0 auto 10px;
-    background: none;
-    border-radius: 0;
-    white-space: nowrap;
-  }
-
-  .form-group {
-    margin-bottom: 16px;
-  }
-
-  .form-group label {
-    display: block;
-    font-size: 0.85rem;
-    margin-bottom: 6px;
-    color: var(--color-text);
-  }
-
-  .form-field {
-    width: 100%;
-    border-radius: 12px;
-    border: 1px solid var(--color-border);
-    padding: 12px 14px;
-    font-size: 0.9rem;
-    background-color: var(--color-white);
-  }
-
-  .form-field:focus {
-    outline: none;
-    border-color: var(--color-primary);
-  }
-
-  .error-message {
-    margin-top: 6px;
-    color: #b97a7a;
-    font-size: 0.85rem;
-    line-height: 1.5;
-  }
-
-  .password-field-wrap {
-    position: relative;
-  }
-
-  .password-field-wrap .form-field {
-    padding-right: 48px;
-  }
-
-  .password-toggle-button {
-    position: absolute;
-    top: 50%;
-    right: 14px;
-    transform: translateY(-50%);
-    border: none;
-    background: none;
-    color: var(--color-text-light);
-    cursor: pointer;
-    padding: 4px;
-  }
-
-  .actions {
-    margin-top: 32px;
-    text-align: center;
-  }
-
-  .submit-btn {
-    max-width: 90%;
-    padding: 12px 16px;
-    background-color: var(--color-primary);
-    color: var(--color-white);
-    font-size: 1rem;
-    box-shadow: 0 4px 10px rgba(127, 183, 126, 0.25);
-    border-radius: 12px;
-    border: none;
-    cursor: pointer;
-}
-
-  .submit-btn:hover {
-    background-color: var(--color-accent);
-  }
-}
-
 #password-reset-request-page {
   background-color: var(--color-primary-light);
   min-height: 100vh;
@@ -133,7 +27,7 @@
     line-height: 1.7;
   }
 
-  form {
+  .form {
     max-width: 420px;
   }
 
@@ -163,10 +57,13 @@
   }
 
   .error-message {
-    margin-top: 6px;
+    display: block;
+    width: 100%;
+    margin: 6px 0 0;
     color: #b97a7a;
     font-size: 0.85rem;
     line-height: 1.5;
+    text-align: left;
   }
 
   .form-actions {
@@ -267,10 +164,51 @@
     box-sizing: border-box;
   }
 
+  .password-field-wrap {
+    position: relative;
+    width: 100%;
+  }
+
+  .password-field-wrap .password-field {
+    padding-right: 48px;
+  }
+
+  .password-toggle-button {
+    position: absolute;
+    top: 50%;
+    right: 14px;
+    transform: translateY(-50%);
+    width: 32px;
+    height: 32px;
+    border: none;
+    background: transparent;
+    color: var(--color-text-light);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+  }
+
+  .error-message {
+    display: block;
+    width: 100%;
+    margin: 6px 0 0;
+    color: #b97a7a;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    text-align: left;
+  }
+
   .form-actions {
     display: flex;
     justify-content: center;
     margin-top: 28px;
+  }
+
+  .actions {
+    margin-top: 32px;
+    display: flex;
+    justify-content: center;
   }
 
   .btn-primary-main {

--- a/app/assets/stylesheets/recordings.scss
+++ b/app/assets/stylesheets/recordings.scss
@@ -3,8 +3,10 @@
 ======================================== */
 #recording-page {
   background-color: var(--color-primary-light);
-  height: 100vh;
+  min-height: 100vh;
   padding: var(--spacing-lg) var(--spacing-md);
+  width: 100%;
+  overflow-x: hidden;
 
   #initial-screen {
     max-width: 420px;
@@ -96,7 +98,7 @@
   .record-guide {
   margin-top: 1.4rem;
   font-size: 0.95rem;
-  color: var(--color--text-light);
+  color: var(--color-text-light);
   line-height: 1.8;
   text-align: center;
   }
@@ -448,6 +450,23 @@
   /* スマホ微調整 */
   @media (max-width: 767px) {
     padding: var(--spacing-md);
+
+    #preview-area {
+      padding: 1.8rem 1rem;
+    }
+
+    #preview-area h2 {
+      font-size: 1.4rem;
+    }
+
+    .duration {
+      font-size: 2.2rem;
+    }
+
+    .preview-save-button {
+      width: 100%;
+      max-width: 280px;
+    }
 
     #initial-screen {
       padding-top: 3rem;
@@ -869,14 +888,15 @@
     text-decoration: none;
   }
 
-  .recording-left {
+  .recording-item-left {
     flex: 1;
     min-width: 0;
   }
 
-  .recording-right {
+  .recording-item-right {
     margin-left: var(--spacing-md);
     flex-shrink: 0;
+    text-align: right;
   }
 
   .recording-title {

--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -2,8 +2,10 @@
   background-color: var(--color-primary-light);
   min-height: 100vh;
   padding: var(--spacing-lg) var(--spacing-md);
+  overflow-x: hidden;
 
   .settings-card {
+    width: 100%;
     max-width: 420px;
     margin: 0 auto;
     background-color: var(--color-white);
@@ -204,6 +206,12 @@
     margin-bottom: 8px;
   }
 
+  input,
+  textarea,
+  select {
+    font-size: 16px;
+  }
+
   .form-field {
     width: 100%;
     height: 52px;
@@ -213,8 +221,18 @@
     color: var(--color-text);
     background-color: var(--color-white);
     font-family: var(--font-main);
-    font-size: 1rem;
+    font-size: 16px;
     box-sizing: border-box;
+  }
+
+  .error-message {
+    margin: 6px auto 0;
+    color: #b97a7a;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    width: 100%;
+    text-align: left;
+    align-self: flex-start;
   }
 
   .form-actions-single {

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -1,16 +1,15 @@
-// app/assets/stylesheets/top.scss
-
 /* ========================================
    トップページ全体のコンテナ
 ======================================== */
 .top-container {
   min-height: 100vh;
   background-color: var(--color-primary-light);
-  display: flex;
-  align-items: center;
-  justify-content: center;
   padding: var(--spacing-xl);
   font-family: var(--font-main);
+}
+
+.top-container .container {
+  max-width: 900px;
 }
 
 /* ========================================
@@ -168,13 +167,13 @@
 
   .top-title {
     font-size: 1.5rem;
-    margin-bottom: 6rem;
+    margin-bottom: 4rem;
   }
 
   .button-group {
     flex-direction: column; /* 縦並び */
     gap: var(--spacing-md);
-    margin-bottom: 6rem;
+    margin-bottom: 4rem;
   }
 
   .button-group .btn {
@@ -190,7 +189,7 @@
   }
 
   .usage-section {
-    margin-top: 80px;
+    margin-top: 64px;
   }
 
   .usage-section h2 {

--- a/app/assets/stylesheets/user_sessions.scss
+++ b/app/assets/stylesheets/user_sessions.scss
@@ -26,6 +26,16 @@
     margin-bottom: var(--spacing-md);
   }
 
+  .error-message {
+    display: block;
+    width: 100%;
+    margin: 6px 0 0;
+    color: #b97a7a;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    text-align: left;
+  }
+
   .form-label {
     display: block;
     margin-bottom: 8px;

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -72,10 +72,13 @@
   }
 
   .error-message {
-    margin: 6px auto 0;
+    display: block;
+    width: 100%;
+    margin: 6px 0 0;
     color: #b97a7a;
     font-size: 0.85rem;
     line-height: 1.5;
+    text-align: left;
   }
 }
 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -4,6 +4,15 @@ class UserSessionsController < ApplicationController
   def new; end
 
   def create
+    @email = params[:email]
+    @email_error = "メールアドレスを入力してください" if params[:email].blank?
+    @password_error = "パスワードを入力してください" if params[:password].blank?
+
+    if @email_error.present? || @password_error.present?
+      render :new, status: :unprocessable_entity
+      return
+    end
+
     @user = login(params[:email], params[:password])
 
     if @user

--- a/app/views/children/new_from_settings.html.erb
+++ b/app/views/children/new_from_settings.html.erb
@@ -8,7 +8,7 @@
         <%= f.text_field :name, class: "form-field" %>
 
         <% if @child.errors[:name].any? %>
-          <div class="errors-message">
+          <div class="error-message">
             <%= @child.errors.full_messages_for(:name).join(", ") %>
           </div>
         <% end %>
@@ -19,7 +19,7 @@
         <%= f.date_field :birthday, class: "form-field date-field" %>
 
         <% if @child.errors[:birthday].any? %>
-          <div class="errors-message">
+          <div class="error-message">
             <%= @child.errors.full_messages_for(:birthday).join(", ") %>
           </div>
         <% end %>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -6,7 +6,11 @@
       新しいパスワードを入力してください
     </p>
 
-    <%= form_with model: @user, url: password_reset_path(token: @token), method: :patch, local: true do |f| %>
+    <%= form_with model: @user,
+                  url: password_reset_path(token: @token),
+                  method: :patch,
+                  local: true,
+                  html: { novalidate: true } do |f| %>
 
       <div class="form-group">
         <%= f.label :password, "新しいパスワード", class: "form-label" %>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -6,7 +6,11 @@
       登録しているメールアドレスを入力してください
     </p>
 
-    <%= form_with url: password_reset_path, method: :post, local: true, data: { turbo: false } do %>
+    <%= form_with url: password_reset_path,
+                  method: :post,
+                  local: true,
+                  data: { turbo: false },
+                  html: { novalidate: true } do %>
       <div class="form-group">
         <%= label_tag :email, "メールアドレス", class: "form-label" %>
         <%= email_field_tag :email, @email,

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -2,15 +2,27 @@
   <div class="login-card">
     <h1 class="login-title">ログイン</h1>
 
-    <%= form_with url: login_path, local: true do |f| %>
+    <%= form_with url: login_path, local: true, html: { novalidate: true } do |f| %>
       <div class="form-group">
         <%= f.label :email, class: "form-label" %>
-        <%= f.email_field :email, class: "form-control", required: true %>
+        <%= f.email_field :email, value: @email, class: "form-control" %>
+
+        <% if @email_error.present? %>
+          <div class="error-message">
+            <%= @email_error %>
+          </div>
+        <% end %>
       </div>
 
       <div class="form-group">
         <%= f.label :password, class: "form-label" %>
-        <%= f.password_field :password, class: "form-control", required: true %>
+        <%= f.password_field :password, class: "form-control" %>
+
+        <% if @password_error.present? %>
+          <div class="error-message">
+            <%= @password_error %>
+          </div>
+        <% end %>
       </div>
 
       <div class="login-actions">
@@ -27,7 +39,7 @@
                     method: :post,
                     data: { turbo: false },
                     html: { class: "line-login-form" } do %>
-        <button type=submit" class="line-login-button">
+        <button type="submit" class="line-login-button">
           <span class="line-icon">
             <%= image_tag "line_icon.png", alt: "LINE", class: "line-icon-img" %>
           </span>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -18,7 +18,11 @@
       </div>
     </div>
 
-    <%= form_with model: @user, url: confirm_users_path, method: :post, data: { turbo: false } do |f| %>
+    <%= form_with model: @user,
+                  url: confirm_users_path,
+                  method: :post,
+                  data: { turbo: false },
+                  html: { novalidate: true } do |f| %>
       <div class="mb-3">
         <%= f.label :name, class: "form-label" %>
         <%= f.text_field :name, class: "form-control" %>


### PR DESCRIPTION
## 概要
スマホ・PC で主要画面が崩れないように調整を行った

## 対象ISSUE
close #181 

## 実装内容
- トップページ
- 新規登録
- ログイン
- 録音画面
- 一覧画面
- 録音詳細画面
- 設定画面
- パスワード再設定
- 利用規約 / プライバシーポリシー
- ログイン画面でフォームを空で進めた場合に表示される、ブラウザ標準バリデーションをOFFにしてRails側で「メールアドレスを入力してください」と表示されるように実装する
- iPhone Safari の「入力欄フォーカス時の自動ズーム」を防止する

## 完了条件
- [ ] スマホで横スクロールが発生しない
- [ ] PCでカード幅が広がりすぎない
- [ ] ボタンや文字が見切れない
- [ ] footer や header が崩れない
- [ ] ログイン画面で入力欄を空で進めた場合に表示さるエラーメッセージが、入力欄下に表示されること
- [ ] スマホでフォーム入力欄をタップした際にiPhone Safari の自動ズーム機能がOFFになっていること