### PR TITLE
トップ画面の上部に余白を追加

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -24,6 +24,7 @@
   font-weight: 600;
   text-align: center;
   color: var(--color-text);
+  margin-top: 3rem;
   margin-bottom: 4rem;
   white-space: nowrap;
 }


### PR DESCRIPTION
本番環境での動作確認で、トップ画面の上部に余白が少なく詰まって見えるためtop.scssに余白を追加。