### PR TITLE
本番環境でS3に保存するよう実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ gem "omniauth"
 gem "omniauth-line"
 gem "omniauth-rails_csrf_protection"
 
+gem "aws-sdk-s3", require: false
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,25 @@ GEM
       activerecord (>= 2.3.0)
       rake (>= 0.8.7)
     ast (2.4.3)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1255.0)
+    aws-sdk-core (3.250.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.128.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.224.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bcrypt (3.1.21)
     bcrypt_pbkdf (1.1.2)
@@ -182,6 +201,7 @@ GEM
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
+    jmespath (1.6.2)
     json (2.19.1)
     json-schema (6.2.0)
       addressable (~> 2.8)
@@ -523,6 +543,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
+  aws-sdk-s3
   better_errors
   binding_of_caller
   bootsnap

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,9 +24,6 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
-
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   config.assume_ssl = true
 
@@ -100,6 +97,5 @@ Rails.application.configure do
 
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
-  # Active Storageの設定
-  config.active_storage.service = :production
+  config.active_storage.service = :amazon
 end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,10 +6,12 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-# 本番環境用（まずはローカルディスクで確認）
-production:
-  service: Disk
-  root: <%= Rails.root.join("storage") %>
+amazon:
+  service: S3
+  access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
+  secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
+  region: ap-northeast-1
+  bucket: kotonoha-audio-storage
 
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:


### PR DESCRIPTION
## 概要

Rednerの本番環境で過去の録音ファイルが再生できないため、Active Storageの保存先をローカルディスクからS3に変更し、録音ファイルを永続的に保存できるようにする。

## 実装内容

- S3バケットを作成する
- AWSアクセスキーを用意する
- `config/storage.yml` に S3設定を追加する
- `production.rb` の Active Storage保存先をS3に変更する
- Renderの環境変数にS3関連情報を設定する
- 本番環境で録音保存・再生できるか確認する

## 完了条件

- [ ]  本番環境で新規録音を保存できる
- [ ]  保存した録音が詳細画面で再生できる
- [ ]  デプロイ後も録音ファイルが消えない
- [ ]  Renderの再起動後も録音ファイルが再生できる
- [ ]  既存の録音が再生できない場合、その理由をREADMEまたはIssueに記録する