### PR TITLE
Set up Resend SMTP for password reset email

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: ENV.fetch("MAIL_FROM", "no-reply@kotonoha-app.com")
   layout "mailer"
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,4 @@
 class UserMailer < ApplicationMailer
-  default from: "no-reply@example.com"
-
   def reset_password_email(user)
     @user = user
     @url = edit_password_reset_url(token: user.reset_password_token)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,17 +71,18 @@ Rails.application.configure do
     protocol: "https"
   }
 
-  # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
-  # config.action_mailer.smtp_settings = {
-  #   user_name: Rails.application.credentials.dig(:smtp, :user_name),
-  #   password: Rails.application.credentials.dig(:smtp, :password),
-  #   address: "smtp.example.com",
-  #   port: 587,
-  #   authentication: :plain
-  # }
+config.action_mailer.delivery_method = :smtp
 
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
+config.action_mailer.smtp_settings = {
+  address: ENV["SMTP_ADDRESS"],
+  port: ENV["SMTP_PORT"],
+  domain: ENV["SMTP_DOMAIN"],
+  user_name: ENV["SMTP_USERNAME"],
+  password: ENV["SMTP_PASSWORD"],
+  authentication: :plain,
+  enable_starttls_auto: true
+}
+
   config.i18n.fallbacks = true
 
   # Do not dump schema after migrations.


### PR DESCRIPTION
## 概要

本番環境ではLetter Openerが使えず、メール送信設定も未実装のため、SMTPまたはメール送信サービスを設定し、パスワード再設定メールを実際のメールアドレスで受信できるようにする。

## 実装内容

- メール送信サービスを選定する
- 本番用SMTP設定を追加する
- production.rb にAction Mailer設定を追加する
- Renderの環境変数にSMTP情報を設定する
- パスワード再設定メールのURLが本番URLになるように設定する
- 本番環境でメール送信・受信・パスワード変更まで確認する

## 完了条件

- [ ]  本番環境でパスワード再設定メールを送信できる
- [ ]  登録メールアドレスにメールが届く
- [ ]  メール内リンクが https://kotonoha-app.com/ のURLになっている
- [ ]  メール内リンクからパスワード再設定画面に遷移できる
- [ ]  新しいパスワードでログインできる
- [ ]  迷惑メールに入る可能性がある場合は確認手順をIssueに記録する