### PR TITLE
Fix LINE login scope for production

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -11,9 +11,10 @@ class OauthsController < ApplicationController
 
     if user.new_record?
       password = SecureRandom.hex(16)
+      uid = auth.uid.to_s
 
       user.name = auth.info.name.presence || "LINEユーザー"
-      user.email = auth.info.email.presence || "line_#{auth.uid}@example.com"
+      user.email = auth.info.email.presence || "line_#{uid}@line.local"
       user.password = password
       user.password_confirmation = password
       user.save!

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,6 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :line,
            ENV["LINE_CHANNEL_ID"],
-           ENV["LINE_CHANNEL_SECRET"]
+           ENV["LINE_CHANNEL_SECRET"],
+           scope: "profile openid"
 end


### PR DESCRIPTION
本番リリース前確認

- [x] LINEログインチャネルをPublishedに変更
- [x] 通常ブラウザで本番LINEログイン成功
- [x] 友人が本番環境でLINEログインできる
- [x] Renderで最新コード反映確認
- [x] 本番DBマイグレーション確認
- [x] 独自ドメインでアクセス確認
- [x] HTTPS確認
- [x] OGP表示確認
- [x] CSS / JS / 画像表示確認
- [x] 録音保存確認
- [x] パスワード再設定メール確認
- [x] スマホ実機確認
- [x] Renderログに致命的エラーなし

補足：
プラーベートブラウザではLINEアプリ遷移後に認証情報が保持されず、
LINEログインに失敗する場合があるため、通常ブラウザで確認する。